### PR TITLE
Implement macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Fixed error context info when raising `UndefinedError` from `StrictUndefined`.
 - Fixed parsing of compound expressions given as filter arguments.
 - Added `Template#docs`, which returns an array of `DocTag` instances used in a template.
+- Added implementations of the `{% macro %}` and `{% call %}` tags.
+- Added `Template#macros`, which returns arrays of `{% macro %}` and `{% call %}` tags used in a template.
 
 ## [0.1.1] - 2025-05-01
 

--- a/README.md
+++ b/README.md
@@ -406,8 +406,8 @@ LIQUID
 template = Liquid2.parse(source)
 macro_tags, call_tags = template.macros
 
-p macro_tags.map(&:name).uniq # ["foo"]
-p call_tags.map(&:name).uniq # ["foo", "bar"]
+p macro_tags.map(&:macro_name).uniq # ["foo"]
+p call_tags.map(&:macro_name).uniq # ["foo", "bar"]
 ```
 
 Finally there's `Template#comments` and `Template#docs`, which return instances of comments nodes and `DocTag` nodes, respectively. Each node has a `token` attribute, including a start index, and a `text` attribute, which is the comment or doc text.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Liquid templates for Ruby, with some extra features.
 - [Links](#links)
 - [About](#about)
 - [API](#api)
-- [Contributing](#contributing)
+- [Development](#development)
 
 ## Install
 
@@ -390,6 +390,24 @@ p template.global_variables # ["you"]
 # ... continued from above
 p template.filter_names # ["upcase", "capitalize"]
 p template.tag_names # ["assign", "for"]
+```
+
+`Template#macros` returns arrays of `{% macro %}` and `{% call %}` tags found in the template.
+
+```ruby
+require "liquid2"
+
+source = <<~LIQUID
+  {% macro foo, you %}Hello, {{ you }}!{% endmacro -%}
+  {% call foo, 'World' %}
+  {% call bar, 'Liquid' %}
+LIQUID
+
+template = Liquid2.parse(source)
+macro_tags, call_tags = template.macros
+
+p macro_tags.map(&:name).uniq # ["foo"]
+p call_tags.map(&:name).uniq # ["foo", "bar"]
 ```
 
 Finally there's `Template#comments` and `Template#docs`, which return instances of comments nodes and `DocTag` nodes, respectively. Each node has a `token` attribute, including a start index, and a `text` attribute, which is the comment or doc text.

--- a/lib/liquid2/context.rb
+++ b/lib/liquid2/context.rb
@@ -171,10 +171,12 @@ module Liquid2
       template_ = @template
       @template = template if template
       @scope << namespace
-      yield
-    ensure
-      @template = template_
-      @scope.pop
+      begin
+        yield
+      ensure
+        @template = template_
+        @scope.pop
+      end
     end
 
     # Copy this render context and add _namespace_ to the new scope.
@@ -222,10 +224,12 @@ module Liquid2
       raise_for_loop_limit(length: forloop.length)
       @loops << forloop
       @scope << namespace
-      yield
-    ensure
-      @scope.pop
-      @loops.pop
+      begin
+        yield
+      ensure
+        @scope.pop
+        @loops.pop
+      end
     end
 
     # Return the last ForLoop obj if one is available, or an instance of Undefined otherwise.

--- a/lib/liquid2/environment.rb
+++ b/lib/liquid2/environment.rb
@@ -27,6 +27,7 @@ require_relative "nodes/tags/include"
 require_relative "nodes/tags/increment"
 require_relative "nodes/tags/inline_comment"
 require_relative "nodes/tags/liquid"
+require_relative "nodes/tags/macro"
 require_relative "nodes/tags/raw"
 require_relative "nodes/tags/render"
 require_relative "nodes/tags/tablerow"
@@ -211,6 +212,8 @@ module Liquid2
       @tags["include"] = IncludeTag
       @tags["increment"] = IncrementTag
       @tags["liquid"] = LiquidTag
+      @tags["macro"] = MacroTag
+      @tags["call"] = CallTag
       @tags["raw"] = RawTag
       @tags["render"] = RenderTag
       @tags["tablerow"] = TableRowTag

--- a/lib/liquid2/expressions/arguments.rb
+++ b/lib/liquid2/expressions/arguments.rb
@@ -22,4 +22,24 @@ module Liquid2
 
     def children = [@value]
   end
+
+  # A macro parameter with a name and optional default value.
+  class Parameter < Expression
+    attr_reader :value, :name, :sym
+
+    # @param name [String]
+    # @param value [Expression?]
+    def initialize(token, name, value)
+      super(token)
+      @name = name
+      @sym = name.to_sym
+      @value = value
+    end
+
+    def evaluate(context)
+      [@name, context.evaluate(@value)]
+    end
+
+    def children = [@value]
+  end
 end

--- a/lib/liquid2/nodes/tags/macro.rb
+++ b/lib/liquid2/nodes/tags/macro.rb
@@ -9,6 +9,7 @@ module Liquid2
 
     END_BLOCK = Set["endmacro"]
 
+    # @param token [[Symbol, String?, Integer]]
     # @param parser [Parser]
     # @return [MacroTag]
     def self.parse(token, parser)
@@ -32,7 +33,7 @@ module Liquid2
     end
 
     def render(context, _buffer)
-      # Macro tags don't render or evaluate anything, just store their arguments list
+      # Macro tags don't render or evaluate anything, just store their parameter list
       # and block on the render context so it can be called later by a `call` tag.
       context.tag_namespace[:macros][@macro_name] = [@params, @block]
     end
@@ -55,6 +56,7 @@ module Liquid2
 
     DISABLED_TAGS = Set["include", "block"]
 
+    # @param token [[Symbol, String?, Integer]]
     # @param parser [Parser]
     # @return [CallTag]
     def self.parse(token, parser)

--- a/lib/liquid2/nodes/tags/macro.rb
+++ b/lib/liquid2/nodes/tags/macro.rb
@@ -5,7 +5,7 @@ require_relative "../../tag"
 module Liquid2
   # The _macro_ tag.
   class MacroTag < Tag
-    attr_reader :name, :params, :block
+    attr_reader :macro_name, :params, :block
 
     END_BLOCK = Set["endmacro"]
 
@@ -25,7 +25,7 @@ module Liquid2
 
     def initialize(token, name, params, block)
       super(token)
-      @name = name
+      @macro_name = name
       @params = params
       @block = block
       @blank = true
@@ -34,7 +34,7 @@ module Liquid2
     def render(context, _buffer)
       # Macro tags don't render or evaluate anything, just store their arguments list
       # and block on the render context so it can be called later by a `call` tag.
-      context.tag_namespace[:macros][@name] = [@params, @block]
+      context.tag_namespace[:macros][@macro_name] = [@params, @block]
     end
 
     def children(_static_context, include_partials: true) = [@block]
@@ -51,7 +51,7 @@ module Liquid2
 
   # The _call_ tag.
   class CallTag < Tag
-    attr_reader :name, :args, :kwargs
+    attr_reader :macro_name, :args, :kwargs
 
     DISABLED_TAGS = Set["include", "block"]
 
@@ -68,7 +68,7 @@ module Liquid2
 
     def initialize(token, name, args, kwargs)
       super(token)
-      @name = name
+      @macro_name = name
       @args = args
       @kwargs = kwargs
       @blank = false
@@ -77,10 +77,10 @@ module Liquid2
     def render(context, buffer)
       # @type var params: Hash[String, Parameter]?
       # @type var block: Block
-      params, block = context.tag_namespace[:macros][@name]
+      params, block = context.tag_namespace[:macros][@macro_name]
 
       unless params
-        buffer << Liquid2.to_output_string(context.env.undefined(@name, node: self))
+        buffer << Liquid2.to_output_string(context.env.undefined(@macro_name, node: self))
         return
       end
 

--- a/lib/liquid2/nodes/tags/macro.rb
+++ b/lib/liquid2/nodes/tags/macro.rb
@@ -1,3 +1,145 @@
 # frozen_string_literal: true
 
-# TODO
+require_relative "../../tag"
+
+module Liquid2
+  # The _macro_ tag.
+  class MacroTag < Tag
+    attr_reader :name, :params, :block
+
+    END_BLOCK = Set["endmacro"]
+
+    # @param parser [Parser]
+    # @return [MacroTag]
+    def self.parse(token, parser)
+      name = parser.parse_name
+      parser.next if parser.current_kind == :token_comma
+      params = parser.parse_parameters
+      parser.next if parser.current_kind == :token_comma
+      parser.carry_whitespace_control
+      parser.eat(:token_tag_end)
+      block = parser.parse_block(END_BLOCK)
+      parser.eat_empty_tag("endmacro")
+      new(token, name, params, block)
+    end
+
+    def initialize(token, name, params, block)
+      super(token)
+      @name = name
+      @params = params
+      @block = block
+      @blank = true
+    end
+
+    def render(context, _buffer)
+      # Macro tags don't render or evaluate anything, just store their arguments list
+      # and block on the render context so it can be called later by a `call` tag.
+      context.tag_namespace[:macros][@name] = [@params, @block]
+    end
+
+    def children(_static_context, include_partials: true) = [@block]
+    def expressions = @params.values.filter_map(&:value)
+
+    def block_scope
+      [
+        Identifier.new([:token_word, "args", @token.last]),
+        Identifier.new([:token_word, "kwargs", @token.last]),
+        *@params.values.map { |param| Identifier.new([:token_word, param.name, param.token.last]) }
+      ]
+    end
+  end
+
+  # The _call_ tag.
+  class CallTag < Tag
+    attr_reader :name, :args, :kwargs
+
+    DISABLED_TAGS = Set["include", "block"]
+
+    # @param parser [Parser]
+    # @return [CallTag]
+    def self.parse(token, parser)
+      name = parser.parse_name
+      parser.next if parser.current_kind == :token_comma
+      args, kwargs = parser.parse_arguments
+      parser.carry_whitespace_control
+      parser.eat(:token_tag_end)
+      new(token, name, args, kwargs)
+    end
+
+    def initialize(token, name, args, kwargs)
+      super(token)
+      @name = name
+      @args = args
+      @kwargs = kwargs
+      @blank = false
+    end
+
+    def render(context, buffer)
+      # @type var params: Hash[String, Parameter]?
+      # @type var block: Block
+      params, block = context.tag_namespace[:macros][@name]
+
+      unless params
+        buffer << Liquid2.to_output_string(context.env.undefined(@name, node: self))
+        return
+      end
+
+      # Parameter names mapped to default values. :undefined is used if there is no default.
+      args = params.values.to_h { |p| [p.name, p.value] }
+      excess_args = [] # : Array[untyped]
+      excess_kwargs = {} # : Hash[String, untyped]
+
+      # Update args with positional arguments.
+      # Keyword arguments are pushed to the end if they appear before positional arguments.
+      names = args.keys
+      length = @args.length
+      index = 0
+      while index < length
+        name = names[index]
+        expr = @args[index]
+        if name.nil?
+          excess_args << expr
+        else
+          args[name] = expr
+        end
+        index += 1
+      end
+
+      # Update args with keyword arguments.
+      @kwargs.each do |arg|
+        if params.include?(arg.name)
+          # This has the potential to override a positional argument.
+          args[arg.name] = arg.value
+        else
+          excess_kwargs[arg.name] = arg.value
+        end
+      end
+
+      # @type var namespace: Hash[String, untyped]
+      namespace = {
+        "args" => excess_args.map { |arg| context.evaluate(arg) },
+        "kwargs" => excess_kwargs.transform_values! { |val| context.evaluate(val) }
+      }
+
+      args.each do |k, v|
+        namespace[k] = if v == :undefined
+                         context.env.undefined(k, node: params[k])
+                       else
+                         context.evaluate(v)
+                       end
+      end
+
+      macro_context = context.copy(
+        namespace,
+        disabled_tags: DISABLED_TAGS,
+        carry_loop_iterations: true
+      )
+
+      block.render(macro_context, buffer)
+    end
+
+    def expressions
+      [*@args, *@kwargs.map(&:value)]
+    end
+  end
+end

--- a/lib/liquid2/nodes/tags/render.rb
+++ b/lib/liquid2/nodes/tags/render.rb
@@ -12,8 +12,6 @@ module Liquid2
     # @return [RenderTag]
     def self.parse(token, parser)
       name = parser.parse_string
-      raise LiquidTypeError, "expected a string literal" unless name.is_a?(String)
-
       repeat = false
       var = nil # : Expression?
       as = nil # : Identifier?

--- a/lib/liquid2/parser.rb
+++ b/lib/liquid2/parser.rb
@@ -396,7 +396,7 @@ module Liquid2
     # @raises [LiquidTypeError].
     def parse_string
       node = parse_primary
-      raise LiquidTypeError, "expected a string" unless node.is_a?(String)
+      raise LiquidTypeError, "expected a string literal" unless node.is_a?(String)
 
       node
     end
@@ -409,6 +409,23 @@ module Liquid2
       end
 
       Identifier.new(token)
+    end
+
+    # Parse a string literals or unquoted word.
+    def parse_name
+      case current_kind
+      when :token_word
+        parse_identifier.name
+      when :token_single_quote_string, :token_double_quote_string
+        node = parse_string_literal
+        unless node.is_a?(String)
+          raise LiquidSyntaxError.new("names can't be template strings", node.token)
+        end
+
+        node
+      else
+        raise LiquidSyntaxError.new("expected a string literal or unquoted word", current)
+      end
     end
 
     # Parse comma separated expression.
@@ -427,7 +444,7 @@ module Liquid2
       args
     end
 
-    # Parse comma name/value pairs.
+    # Parse comma separated name/value pairs.
     # Leading commas should be consumed by the caller, if allowed.
     # @return [Array<KeywordArgument>]
     def parse_keyword_arguments
@@ -438,8 +455,7 @@ module Liquid2
 
         word = eat(:token_word)
         eat_one_of(:token_assign, :token_colon)
-        val = parse_primary
-        args << KeywordArgument.new(word, word[1] || raise, val)
+        args << KeywordArgument.new(word, word[1] || raise, parse_primary)
 
         break unless current_kind == :token_comma
 
@@ -447,6 +463,68 @@ module Liquid2
       end
 
       args
+    end
+
+    # Parse comma separated parameter names with optional default expressions.
+    # Leading commas should be consumed by the caller, if allowed.
+    # @return [Hash[String, Parameter]]
+    def parse_parameters
+      args = {} # : Hash[String, Parameter]
+
+      loop do
+        break if TERMINATE_EXPRESSION.member?(current_kind)
+
+        word = eat(:token_word)
+        name = word[1] || raise
+
+        case current_kind
+        when :token_assign, :token_colon
+          @pos += 1
+          args[name] = Parameter.new(word, name, parse_primary)
+          @pos += 1 if current_kind == :token_comma
+        when :comma
+          args[name] = Parameter.new(word, name, :undefined)
+          @pos += 1
+        else
+          args[name] = Parameter.new(word, name, :undefined)
+          break
+        end
+      end
+
+      args
+    end
+
+    # Parse positional and keyword arguments.
+    # Leading commas should be consumed by the caller, if allowed.
+    # @return [[Array[untyped], Array[KeywordArgument]]]
+    def parse_arguments
+      args = [] # : Array[untyped]
+      kwargs = [] # : Array[KeywordArgument]
+
+      loop do
+        break if TERMINATE_EXPRESSION.member?(current_kind)
+
+        case current_kind
+        when :token_word
+          if KEYWORD_ARGUMENT_DELIMITERS.include?(peek_kind)
+            token = self.next
+            @pos += 1 # = or :
+            kwargs << KeywordArgument.new(token, token[1] || raise, parse_primary)
+          else
+            # A positional argument
+            args << parse_primary
+          end
+        else
+          # A positional argument
+          args << parse_primary
+        end
+
+        break unless current_kind == :token_comma
+
+        @pos += 1
+      end
+
+      [args, kwargs]
     end
 
     protected

--- a/lib/liquid2/parser.rb
+++ b/lib/liquid2/parser.rb
@@ -494,7 +494,7 @@ module Liquid2
       args
     end
 
-    # Parse positional and keyword arguments.
+    # Parse mixed positional and keyword arguments.
     # Leading commas should be consumed by the caller, if allowed.
     # @return [[Array[untyped], Array[KeywordArgument]]]
     def parse_arguments

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -2390,7 +2390,7 @@ end
 module Liquid2
   # The _macro_ tag.
   class MacroTag < Tag
-    @name: String
+    @macro_name: String
 
     @params: Hash[String, Parameter]
 
@@ -2400,7 +2400,7 @@ module Liquid2
 
     END_BLOCK: Set[String]
 
-    attr_reader name: String
+    attr_reader macro_name: String
 
     attr_reader params: Hash[String, Parameter]
 
@@ -2417,7 +2417,7 @@ module Liquid2
 
   # The _call_ tag.
   class CallTag < Tag
-    @name: String
+    @macro_name: String
 
     @args: Array[untyped]
 
@@ -2427,7 +2427,7 @@ module Liquid2
 
     DISABLED_TAGS: Set[String]
 
-    attr_reader name: String
+    attr_reader macro_name: String
 
     attr_reader args: Array[untyped]
 

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -848,7 +848,7 @@ module Liquid2
     @loops: Array[ForLoop]
 
     # A stack of interrupts used to signal breaking and continuing `for` loops.
-    @interrupts: Array[:break | :continue]
+    @interrupts: Array[Symbol]
 
     attr_reader env: Environment
 
@@ -860,7 +860,7 @@ module Liquid2
 
     attr_reader tag_namespace: Hash[Symbol, untyped]
 
-    attr_accessor interrupts: Array[:break | :continue]
+    attr_accessor interrupts: Array[Symbol]
 
 
     BUILT_IN: BuiltIn
@@ -929,16 +929,13 @@ module Liquid2
 
     def get_output_buffer: (untyped parent_buffer) -> untyped
 
-    # Mark _string_ as "safe" if auto escape is enabled.
-    def markup: (untyped string) -> untyped
-
     def cycle: (untyped key, untyped length) -> untyped
 
-    def increment: (untyped name) -> untyped
+    def increment: (untyped name) -> Integer
 
-    def decrement: (untyped name) -> untyped
+    def decrement: (untyped name) -> Integer
 
-    def assign_score: (untyped value) -> untyped
+    def assign_score: (untyped value) -> Integer
 
   end
 end

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -344,6 +344,8 @@ module Liquid2
     def parse_string: () -> String
 
     def parse_identifier: (?trailing_question: bool) -> Identifier
+                        
+    def parse_name: () -> String
 
     # Parse comma separated expression.
     # Leading commas should be consumed by the caller.
@@ -354,6 +356,10 @@ module Liquid2
     # Leading commas should be consumed by the caller.
     # @return [Array<KeywordArgument>]
     def parse_keyword_arguments: () -> Array[KeywordArgument]
+                               
+    def parse_parameters: () -> Hash[String, Parameter]
+                        
+    def parse_arguments: () -> [Array[untyped], Array[KeywordArgument]]
 
     class Precedence
       LOWEST: 1
@@ -498,6 +504,8 @@ module Liquid2
     def comments: () -> Array[BlockComment | InlineComment | Comment]
                 
     def docs: () -> Array[DocTag]
+            
+    def macros: (?include_partials: bool) -> [Array[MacroTag], Array[CallTag]]
                 
     # Return an array of variables used in this template, without path segments.
     # @param include_partials [bool]
@@ -1120,6 +1128,26 @@ module Liquid2
     attr_reader sym: Symbol
 
     attr_reader value: untyped
+
+    # @param name [Token]
+    # @param value [Expression]
+    def initialize: ([Symbol, String?, Integer] token, String name, untyped value) -> void
+
+    def evaluate: (RenderContext context) -> [String, untyped]
+  end
+
+  class Parameter < Expression
+    @name: String
+
+    @sym: Symbol
+
+    @value: untyped
+
+    attr_reader name: String
+
+    attr_reader sym: Symbol
+
+    attr_reader value: (untyped | :undefined)
 
     # @param name [Token]
     # @param value [Expression]
@@ -2356,5 +2384,61 @@ module Liquid2
   module Filters
     # Return _left_ serialized in JSON format.
     def self.json: (untyped left, ?pretty: bool) -> String
+  end
+end
+
+module Liquid2
+  # The _macro_ tag.
+  class MacroTag < Tag
+    @name: String
+
+    @params: Hash[String, Parameter]
+
+    @block: Block
+
+    @blank: bool
+
+    END_BLOCK: Set[String]
+
+    attr_reader name: String
+
+    attr_reader params: Hash[String, Parameter]
+
+    attr_reader Block: Block
+
+    # @param parser [Parser]
+    # @return [MacroTag]
+    def self.parse: ([Symbol, String?, Integer] token, Parser parser) -> MacroTag
+
+    def initialize: ([Symbol, String?, Integer] token, String name, Hash[String, Parameter] params, Block block) -> void
+
+    def render: (RenderContext context, String _buffer) -> void
+  end
+
+  # The _call_ tag.
+  class CallTag < Tag
+    @name: String
+
+    @args: Array[untyped]
+
+    @kwargs: Array[KeywordArgument]
+
+    @blank: bool
+
+    DISABLED_TAGS: Set[String]
+
+    attr_reader name: String
+
+    attr_reader args: Array[untyped]
+
+    attr_reader kwargs: Array[KeywordArgument]
+
+    # @param parser [Parser]
+    # @return [CallTag]
+    def self.parse: ([Symbol, String?, Integer] token, Parser parser) -> CallTag
+
+    def initialize: ([Symbol, String?, Integer] token, String name, Array[untyped] args, Array[KeywordArgument] kwargs) -> void
+
+    def render: (RenderContext context, String buffer) -> void
   end
 end

--- a/test/test_macros.rb
+++ b/test/test_macros.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MockUndefined < Liquid2::Undefined
+  def to_s = "UNDEFINED"
+end
+
+class TestMacros < Minitest::Test
+  def test_define_a_macro
+    source = "{% macro 'func' %}Hello, World!{% endmacro %}"
+
+    assert_equal("", Liquid2.render(source))
+  end
+
+  def test_define_and_call_a_macro
+    source = "{% macro 'func' %}Hello, World!{% endmacro %}{% call 'func' %}"
+
+    assert_equal("Hello, World!", Liquid2.render(source))
+  end
+
+  def test_unquoted_macro_names
+    source = "{% macro func %}Hello, World!{% endmacro %}{% call 'func' %}{% call func %}"
+
+    assert_equal("Hello, World!Hello, World!", Liquid2.render(source))
+  end
+
+  def test_single_positional_argument
+    source = <<~LIQUID.chomp
+      {% macro func, you %}Hello, {{ you }}!{% endmacro -%}
+      {% call func, 'World' %}
+      {% call func, 'Liquid' %}
+    LIQUID
+
+    assert_equal("Hello, World!\nHello, Liquid!", Liquid2.render(source))
+  end
+
+  def test_single_default_argument
+    source = <<~LIQUID.chomp
+      {% macro func, you='Brian' %}Hello, {{ you }}!{% endmacro -%}
+      {% call func %}
+      {% call func, 'Liquid' %}
+    LIQUID
+
+    assert_equal("Hello, Brian!\nHello, Liquid!", Liquid2.render(source))
+  end
+
+  def test_call_default_argument_by_name
+    source = <<~LIQUID.chomp
+      {% macro func, you='Brian' %}Hello, {{ you }}!{% endmacro -%}
+      {% call func %}
+      {% call func, you='Liquid' %}
+    LIQUID
+
+    assert_equal("Hello, Brian!\nHello, Liquid!", Liquid2.render(source))
+  end
+
+  def test_variable_default_argument
+    source = <<~LIQUID.chomp
+      {% macro func, you=a.b %}Hello, {{ you }}!{% endmacro -%}
+      {% call func %}
+      {% call func, you='Liquid' %}
+    LIQUID
+
+    data = { "a" => { "b" => "Brian" } }
+
+    assert_equal("Hello, Brian!\nHello, Liquid!", Liquid2.render(source, data))
+  end
+
+  def test_rest_arguments
+    source = <<~LIQUID.chomp
+      {% macro func %}{{ args | join: '-' }}{% endmacro -%}
+      {% call func 1, 2, 3 %}
+    LIQUID
+
+    assert_equal("1-2-3", Liquid2.render(source))
+  end
+
+  def test_rest_keyword_arguments
+    source = <<~LIQUID.chomp
+      {% macro 'func' -%}
+      {% for arg in kwargs -%}
+      {{ "${arg[0]} => ${arg[1]}, " -}}
+      {% endfor -%}
+      {% endmacro -%}
+      {% call 'func', a: 1, b: 2 %}
+    LIQUID
+
+    assert_equal("a => 1, b => 2, ", Liquid2.render(source))
+  end
+
+  def test_missing_arguments_are_undefined
+    source = <<~LIQUID.chomp
+      {% macro func, foo %}{{ foo }}{% endmacro -%}
+      {% call func %}
+    LIQUID
+
+    env = Liquid2::Environment.new(undefined: MockUndefined)
+
+    assert_equal("UNDEFINED", env.render(source))
+  end
+
+  def test_template_assigns_are_out_of_scope
+    source = <<~LIQUID.chomp
+      {% assign foo = "42" -%}
+      {% macro func, foo %}{{ foo }}{% endmacro -%}
+      {% call func %}
+    LIQUID
+
+    env = Liquid2::Environment.new(undefined: MockUndefined)
+
+    assert_equal("UNDEFINED", env.render(source))
+  end
+
+  def test_macro_assigns_go_out_of_scope
+    source = <<~LIQUID.chomp
+      {% macro func, foo %}{% assign foo = "42" %}{{ foo }}{% endmacro -%}
+      {% call func %}
+      {{ foo }}!
+    LIQUID
+
+    assert_equal("42\n!", Liquid2.render(source))
+  end
+
+  def test_undefined_macro
+    source = <<~LIQUID.chomp
+      {% call func %}
+    LIQUID
+
+    env = Liquid2::Environment.new(undefined: MockUndefined)
+
+    assert_equal("UNDEFINED", env.render(source))
+  end
+
+  def test_default_argument_before_positional
+    source = <<~LIQUID.chomp
+      {% macro 'func' you: 'brian', greeting -%}
+      {{ greeting }}, {{ you }}!
+      {% endmacro -%}
+      {% call 'func' -%}
+      {% call 'func' you: 'World', greeting: 'Goodbye' %}
+    LIQUID
+
+    assert_equal(", brian!\nGoodbye, World!\n", Liquid2.render(source))
+  end
+
+  def test_trailing_commas
+    source = <<~LIQUID.chomp
+      {% macro func, you, %}Hello, {{ you }}!{% endmacro -%}
+      {% call func, 'World', %}
+      {% call func, 'Liquid', %}
+    LIQUID
+
+    assert_equal("Hello, World!\nHello, Liquid!", Liquid2.render(source))
+  end
+end

--- a/test/test_static_analysis_helpers.rb
+++ b/test/test_static_analysis_helpers.rb
@@ -80,8 +80,8 @@ class TestStaticAnalysisHelpers < Minitest::Test
     assert_equal(1, macro_tags.length)
     assert_equal(2, call_tags.length)
 
-    macro_names = macro_tags.map(&:name)
-    call_names = call_tags.map(&:name)
+    macro_names = macro_tags.map(&:macro_name)
+    call_names = call_tags.map(&:macro_name)
 
     assert_equal(["func"], macro_names)
     assert_equal(%w[func nosuchthing], call_names)

--- a/test/test_static_analysis_helpers.rb
+++ b/test/test_static_analysis_helpers.rb
@@ -66,4 +66,24 @@ class TestStaticAnalysisHelpers < Minitest::Test
   def test_get_tag_names
     assert_equal(%w[assign for], TEMPLATE.tag_names)
   end
+
+  def test_get_macros
+    source = <<~LIQUID.chomp
+      {% macro func, you=a.b %}Hello, {{ you }}!{% endmacro -%}
+      {% call func %}
+      {% call nosuchthing, you='Liquid' %}
+    LIQUID
+
+    template = Liquid2.parse(source)
+    macro_tags, call_tags = template.macros
+
+    assert_equal(1, macro_tags.length)
+    assert_equal(2, call_tags.length)
+
+    macro_names = macro_tags.map(&:name)
+    call_names = call_tags.map(&:name)
+
+    assert_equal(["func"], macro_names)
+    assert_equal(%w[func nosuchthing], call_names)
+  end
 end


### PR DESCRIPTION
This PR implements `{% macro %}` and `{% call %}`.

The `macro` tag defines a parameterized block that can later be called using the `call` tag. For example.

```liquid
{% macro 'price', product, on_sale: false %}
  <div class="price-wrapper">
  {% if on_sale %}
    <p>Was {{ product.regular_price | prepend: '$' }}</p>
    <p>Now {{ product.price | prepend: '$' }}</p>
  {% else %}
    <p>{{ product.price | prepend: '$' }}</p>
  {% endif %}
  </div>
{% endmacro %}

{% call 'price', products[0], on_sale: true %}
{% call 'price', products[1] %}
```

We've chosen to render macros in their own, isolated scope, with `{% macro %}` parameter defaults binding late. This means they don't "close over" variables in their parent scope, they can't call themselves recursively and they can't change or add variables to their parent scope.

These choices and the fairly lax handling of positional and keyword arguments wont suit everyone, but serves as an example or starting point for anyone wishing to implement their own version of `{% macro %}` and `{% call %}`.