### PR TITLE
Implement `{% extends %}` and `{% block %}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added `Template#docs`, which returns an array of `DocTag` instances used in a template.
 - Added implementations of the `{% macro %}` and `{% call %}` tags.
 - Added `Template#macros`, which returns arrays of `{% macro %}` and `{% call %}` tags used in a template.
+- Added template inheritance tags `{% extends %}` and `{% block %}`.
 
 ## [0.1.1] - 2025-05-01
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,12 @@ Here we use `~` to remove the newline after the opening `for` tag, but preserve 
 
 Integer and float literals can use scientific notation, like `1.2e3` or `1e-2`.
 
+#### Extra tags and filters
+
+Liquid2 includes implementations of `{% extends %}` and `{% block %}` for template inheritance, and `{% macro %}` and `{% call %}` for defining parameterized blocks.
+
+There's also built-in implementations of `sort_numeric` and `json` filters.
+
 ## API
 
 ### Liquid2.render
@@ -243,7 +249,7 @@ This is a convenience method equivalent to `Liquid2::DEFAULT_ENVIRONMENT.parse(s
 
 `self.parse: (String source, ?globals: Hash[String, untyped]?) -> Template`
 
-Parse or "compile" Liquid template _source_ using the default Liquid environment. The resulting `Liquid2::Template` instance has a `render(data)` methods, which can be called multiple times with different data.
+Parse or "compile" Liquid template _source_ using the default Liquid environment. The resulting `Liquid2::Template` instance has a `render(data)` method, which can be called multiple times with different data.
 
 ```ruby
 require "liquid2"

--- a/lib/liquid2/context.rb
+++ b/lib/liquid2/context.rb
@@ -208,13 +208,17 @@ module Liquid2
                 ReadOnlyChainHash.new(@globals, namespace)
               end
 
-      self.class.new(template || @template,
-                     globals: scope,
-                     disabled_tags: disabled_tags,
-                     copy_depth: @copy_depth + 1,
-                     parent: self,
-                     loop_carry: loop_carry,
-                     local_namespace_carry: @assign_score)
+      context = self.class.new(template || @template,
+                               globals: scope,
+                               disabled_tags: disabled_tags,
+                               copy_depth: @copy_depth + 1,
+                               parent: self,
+                               loop_carry: loop_carry,
+                               local_namespace_carry: @assign_score)
+
+      # XXX: bit of a hack
+      context.tag_namespace[:extends] = @tag_namespace[:extends]
+      context
     end
 
     # Push a new namespace and forloop for the duration of a block.

--- a/lib/liquid2/context.rb
+++ b/lib/liquid2/context.rb
@@ -29,8 +29,8 @@ module Liquid2
   # Per render contextual information. A new RenderContext is created automatically
   # every time `Template#render` is called.
   class RenderContext
-    attr_reader :env, :template, :disabled_tags, :globals
-    attr_accessor :interrupts, :tag_namespace
+    attr_reader :env, :disabled_tags, :globals
+    attr_accessor :interrupts, :tag_namespace, :template
 
     BUILT_IN = BuiltIn.new
 

--- a/lib/liquid2/context.rb
+++ b/lib/liquid2/context.rb
@@ -173,6 +173,10 @@ module Liquid2
       @scope << namespace
       begin
         yield
+      rescue LiquidError => e
+        e.template_name = template.full_name if template && !e.template_name
+        e.source = template.source if template && !e.source
+        raise
       ensure
         @template = template_
         @scope.pop

--- a/lib/liquid2/environment.rb
+++ b/lib/liquid2/environment.rb
@@ -21,6 +21,7 @@ require_relative "nodes/tags/cycle"
 require_relative "nodes/tags/decrement"
 require_relative "nodes/tags/doc"
 require_relative "nodes/tags/echo"
+require_relative "nodes/tags/extends"
 require_relative "nodes/tags/for"
 require_relative "nodes/tags/if"
 require_relative "nodes/tags/include"
@@ -207,6 +208,8 @@ module Liquid2
       @tags["decrement"] = DecrementTag
       @tags["doc"] = DocTag
       @tags["echo"] = EchoTag
+      @tags["extends"] = ExtendsTag
+      @tags["block"] = BlockTag
       @tags["for"] = ForTag
       @tags["if"] = IfTag
       @tags["include"] = IncludeTag

--- a/lib/liquid2/environment.rb
+++ b/lib/liquid2/environment.rb
@@ -145,8 +145,8 @@ module Liquid2
                    name: name, path: path, up_to_date: up_to_date,
                    globals: make_globals(globals), overlay: overlay)
     rescue LiquidError => e
-      e.source = source
-      e.template_name = name unless name.empty?
+      e.source = source unless e.source
+      e.template_name = name unless e.template_name || name.empty?
       raise
     end
 

--- a/lib/liquid2/errors.rb
+++ b/lib/liquid2/errors.rb
@@ -7,10 +7,10 @@ module Liquid2
 
     FULL_MESSAGE = ((RUBY_VERSION.split(".")&.map(&:to_i) <=> [3, 2, 0]) || -1) < 1
 
-    def initialize(message, token = nil)
+    def initialize(message, token = nil, template_name: nil)
       super(message)
       @token = token
-      @template_name = nil
+      @template_name = template_name
       @source = nil
     end
 
@@ -76,4 +76,6 @@ module Liquid2
   class LiquidResourceLimitError < LiquidError; end
   class UndefinedError < LiquidError; end
   class DisabledTagError < LiquidError; end
+  class TemplateInheritanceError < LiquidError; end
+  class RequiredBlockError < TemplateInheritanceError; end
 end

--- a/lib/liquid2/loader.rb
+++ b/lib/liquid2/loader.rb
@@ -31,6 +31,7 @@ module Liquid2
     def load(env, name, globals: nil, context: nil, **kwargs)
       data = get_source(env, name, context: context, **kwargs)
       path = Pathname.new(data.name)
+      # FIXME: name and path
       env.parse(data.source,
                 name: path.basename.to_s,
                 path: data.name,

--- a/lib/liquid2/nodes/tags/extends.rb
+++ b/lib/liquid2/nodes/tags/extends.rb
@@ -1,3 +1,259 @@
 # frozen_string_literal: true
 
-# TODO
+require_relative "../../tag"
+
+module Liquid2
+  # The _extends_ tag.
+  class ExtendsTag < Tag
+    attr_reader :template_name
+
+    # @param token [[Symbol, String?, Integer]]
+    # @param parser [Parser]
+    # @return [ExtendsTag]
+    def self.parse(token, parser)
+      name = parser.parse_name
+      parser.carry_whitespace_control
+      parser.eat(:token_tag_end)
+      new(token, name)
+    end
+
+    def initialize(token, name)
+      super(token)
+      @template_name = name
+      @blank = false
+    end
+
+    def render(context, buffer)
+      base_template = stack_blocks(context, context.template)
+      base_template&.render_with_context(context, buffer)
+      context.tag_namespace[:extends].clear
+      context.interrupts << :stop_render
+    end
+
+    def children(static_context, include_partials: true)
+      return [] unless include_partials
+
+      begin
+        parent = static_context.env.get_template(
+          @template_name,
+          context: static_context,
+          tag: "extends"
+        )
+        parent.ast
+      rescue LiquidTemplateNotFoundError => e
+        e.token = @token
+        e.template_name = static_context.template.full_name
+        raise e
+      end
+    end
+
+    def partial_scope
+      Partial.new(@template_name, :inherited, [])
+    end
+
+    protected
+
+    # Visit all templates in the inheritance chain and build a stack for each `block` tag.
+    def stack_blocks(context, template)
+      # @type var stacks: Hash[String, Array[untyped]]
+      stacks = context.tag_namespace[:extends]
+
+      # Guard against recursive `extends`.
+      seen_extends = Set[] # : Set[String]
+
+      # @type var stack_blocks_: ^(Template) -> Template?
+      stack_blocks_ = lambda do |template_|
+        extends_nodes, block_nodes = inheritance_nodes(context, template_)
+        template_name = template_.path || template_.name
+
+        if extends_nodes.length > 1
+          raise TemplateInheritanceError.new("too many 'extends' tags", extends_nodes[1].token,
+                                             template_name: template_name)
+        end
+
+        # Identify duplicate blocks.
+        seen_blocks = Set[] # : Set[String]
+
+        block_nodes.each do |block|
+          if seen_blocks.include?(block.block_name)
+            raise TemplateInheritanceError.new("duplicate block #{block.block_name.inspect}",
+                                               block.token, template_name: template_name)
+          end
+
+          seen_blocks.add(block.block_name)
+
+          stack = stacks[block.block_name]
+          required = !stack.empty? && !block.required ? false : block.required
+          # [block, required, template name, parent]
+          # [BlockTag, bool, String, untyped?]
+          stack << [block, required, template_name, nil]
+          # Populate parent block.
+          stack[-2][-1] = stack.last if stack.length > 1
+        end
+
+        return nil if extends_nodes.empty? # steep:ignore
+
+        extends_node = extends_nodes.first
+
+        if seen_extends.include?(extends_node.template_name)
+          raise TemplateInheritanceError.new(
+            "circular extends #{extends_node.template_name.inspect}",
+            extends_node.token,
+            template_name: template_name
+          )
+        end
+
+        seen_extends.add(extends_node.template_name)
+
+        begin
+          context.env.get_template(extends_node.template_name, context: context, tag: "extends")
+        rescue LiquidTemplateNotFoundError => e
+          e.token = extends_node.token
+          e.template_name = template_.full_name
+          raise e
+        end
+      end
+
+      # @type var next_template: Template?
+      base = next_template = stack_blocks_.call(template)
+
+      while next_template
+        next_template = stack_blocks_.call(next_template)
+        base = next_template if next_template
+      end
+
+      base
+    end
+
+    # Traverse the template's syntax tree looking for `{% extends %}` and `{% block %}`.
+    # @return [[Array[ExtendsTag], Array[BlockTag]]]
+    def inheritance_nodes(context, template)
+      extends_nodes = [] # : Array[ExtendsTag]
+      block_nodes = [] # : Array[BlockTag]
+
+      # @type var visit: ^(Node) -> void
+      visit = lambda do |node|
+        extends_nodes << node if node.is_a?(ExtendsTag)
+        block_nodes << node if node.is_a?(BlockTag)
+
+        node.children(context, include_partials: false).each do |child|
+          visit.call(child) if child.is_a?(Node)
+        end
+      end
+
+      template.ast.each { |node| visit.call(node) if node.is_a?(Node) }
+
+      [extends_nodes, block_nodes]
+    end
+  end
+
+  # The _block_ tag.
+  class BlockTag < Tag
+    attr_reader :block_name, :required, :block
+
+    END_BLOCK = Set["endblock"]
+
+    # @param token [[Symbol, String?, Integer]]
+    # @param parser [Parser]
+    # @return [BlockTag]
+    def self.parse(token, parser)
+      block_name = parser.parse_name
+      required = if parser.current_kind == :token_required
+                   parser.next
+                   true
+                 else
+                   false
+                 end
+
+      parser.carry_whitespace_control
+      parser.eat(:token_tag_end)
+      block = parser.parse_block(END_BLOCK)
+      parser.eat_empty_tag("endblock")
+      new(token, block_name, block, required: required)
+    end
+
+    def initialize(token, name, block, required:)
+      super(token)
+      @block_name = name
+      @block = block
+      @required = required
+      @blank = false
+    end
+
+    def render(context, buffer)
+      # @type var stack: Array[[BlockTag, bool, String, untyped?]]
+      stack = context.tag_namespace[:extends][@block_name]
+
+      if stack.empty?
+        # This base block is being rendered directly.
+        if @required
+          raise RequiredBlockError.new("block #{@block_name.inspect} must be overridden",
+                                       @token)
+        end
+
+        context.extend({ "block" => BlockDrop.new(token, context, @block_name, nil) }) do
+          @block.render(context, buffer)
+        end
+
+        return
+      end
+
+      block_tag, required, template_name, parent = stack.first
+
+      if required
+        raise RequiredBlockError.new("block #{@block_name.inspect} must be overridden", @token,
+                                     template_name: template_name)
+      end
+
+      namespace = { "block" => BlockDrop.new(token, context, @block_name, parent) }
+      block_context = context.copy(namespace, carry_loop_iterations: true, block_scope: true)
+      block_tag.block.render(block_context, buffer)
+    end
+
+    def children(_static_context, include_partials: true)
+      [@block]
+    end
+
+    def block_scope
+      [Identifier.new([:token_word, "block", @token.last])]
+    end
+  end
+
+  # A `block` object available within `{% block %}` tags.
+  class BlockDrop
+    attr_reader :token
+
+    # @param token [[Symbol, String?, Integer]]
+    # @param context [RenderContext]
+    # @param name [String]
+    # @param parent [[BlockTag, bool, String, Block?]?]
+    def initialize(token, context, name, parent)
+      @token = token
+      @context = context
+      @name = name
+      @parent = parent
+    end
+
+    def to_s = "BlockDrop(#{@name})"
+
+    def key?(key)
+      key == "super"
+    end
+
+    def [](key)
+      return @context.env.undefined(key, node: self) if key != "super" || @parent.nil?
+
+      parent = @parent || raise
+      buf = +""
+      namespace = { "block" => BlockDrop.new(parent.first.token,
+                                             @context,
+                                             parent[2],
+                                             parent.last) }
+      @context.extend(namespace) do
+        parent.first.block.render(@context, buf)
+      end
+
+      buf.freeze
+    end
+  end
+end

--- a/lib/liquid2/nodes/tags/extends.rb
+++ b/lib/liquid2/nodes/tags/extends.rb
@@ -25,7 +25,9 @@ module Liquid2
 
     def render(context, buffer)
       base_template = stack_blocks(context, context.template)
-      base_template&.render_with_context(context, buffer)
+      context.extend({}, template: base_template) do
+        base_template&.render_with_context(context, buffer)
+      end
       context.tag_namespace[:extends].clear
       context.interrupts << :stop_render
     end
@@ -187,7 +189,7 @@ module Liquid2
       if stack.empty?
         # This base block is being rendered directly.
         if @required
-          raise RequiredBlockError.new("block #{@block_name.inspect} must be overridden",
+          raise RequiredBlockError.new("block #{@block_name.inspect} is required",
                                        @token)
         end
 
@@ -201,7 +203,7 @@ module Liquid2
       block_tag, required, template_name, parent = stack.first
 
       if required
-        raise RequiredBlockError.new("block #{@block_name.inspect} must be overridden", @token,
+        raise RequiredBlockError.new("block #{@block_name.inspect} is required", @token,
                                      template_name: template_name)
       end
 

--- a/lib/liquid2/nodes/tags/include.rb
+++ b/lib/liquid2/nodes/tags/include.rb
@@ -47,7 +47,7 @@ module Liquid2
     # @param args [Array<KeywordArgument> | nil]
     def initialize(token, name, repeat, var, as, args)
       super(token)
-      @name = name
+      @template_name = name
       @repeat = repeat
       @var = var
       @as = as
@@ -56,7 +56,7 @@ module Liquid2
     end
 
     def render(context, buffer)
-      name = context.evaluate(@name)
+      name = context.evaluate(@template_name)
       template = context.env.get_template(name.to_s, context: context, tag: :include)
       namespace = @args.to_h { |arg| [arg.name, context.evaluate(arg.value)] }
 
@@ -90,7 +90,7 @@ module Liquid2
     def children(static_context, include_partials: true)
       return [] unless include_partials
 
-      name = static_context.evaluate(@name)
+      name = static_context.evaluate(@template_name)
       template = static_context.env.get_template(name.to_s, context: static_context, tag: :include)
       template.ast
     rescue LiquidTemplateNotFoundError => e
@@ -100,7 +100,7 @@ module Liquid2
     end
 
     def expressions
-      exprs = [@name]
+      exprs = [@template_name]
       exprs << @var if @var
       exprs.concat(@args.map(&:value))
       exprs
@@ -112,12 +112,12 @@ module Liquid2
       if @var
         if @as
           scope << @as # steep:ignore
-        elsif @name.is_a?(String)
-          scope << Identifier.new([:token_word, @name.split(".").first, @token.last])
+        elsif @template_name.is_a?(String)
+          scope << Identifier.new([:token_word, @template_name.split(".").first, @token.last])
         end
       end
 
-      Partial.new(@name, :shared, scope)
+      Partial.new(@template_name, :shared, scope)
     end
   end
 end

--- a/lib/liquid2/template.rb
+++ b/lib/liquid2/template.rb
@@ -59,6 +59,8 @@ module Liquid2
 
           next unless (interrupt = context.interrupts.pop)
 
+          break if interrupt == :stop_render
+
           if !partial || block_scope
             raise LiquidSyntaxError.new("unexpected #{interrupt}",
                                         node.token) # steep:ignore

--- a/lib/liquid2/template.rb
+++ b/lib/liquid2/template.rb
@@ -71,8 +71,8 @@ module Liquid2
         end
       end
     rescue LiquidError => e
-      e.source = @source
-      e.template_name = @name unless @name.empty?
+      e.source = context.template.source unless e.source
+      e.template_name = @name unless e.template_name || @name.empty?
       raise
     end
 

--- a/lib/liquid2/undefined.rb
+++ b/lib/liquid2/undefined.rb
@@ -39,7 +39,7 @@ module Liquid2
   class StrictUndefined < Undefined
     def initialize(name, node: nil)
       super
-      @message = "#{name.inspect} is undefined"
+      @message = "#{@node.is_a?(Path) ? @node : name.inspect} is undefined"
     end
 
     def respond_to_missing? = true

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -475,6 +475,8 @@ module Liquid2
 
     attr_reader up_to_date: Proc::_Callable?
 
+    attr_reader source: String
+
     # @param env [Environment]
     # @param ast [RootNode]
     # @param name [String] The template's name.
@@ -852,7 +854,7 @@ module Liquid2
 
     attr_reader env: Environment
 
-    attr_reader template: Template
+    attr_accessor template: Template
 
     attr_reader globals: _Namespace
 

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -957,7 +957,7 @@ module Liquid2
 
     attr_accessor source: (String | nil)
 
-    def initialize: (String message, ?[Symbol, String?, Integer]? token) -> void
+    def initialize: (String message, ?[Symbol, String?, Integer]? token, ?template_name: String?) -> void
                   
     def detailed_message: (?highlight: bool, **untyped kwargs) -> String
 
@@ -988,6 +988,12 @@ module Liquid2
   end
 
   class DisabledTagError < LiquidError
+  end
+
+  class TemplateInheritanceError < LiquidError
+  end
+
+  class RequiredBlockError < TemplateInheritanceError
   end
 
   # The standard _for_ tag.
@@ -2021,7 +2027,7 @@ end
 module Liquid2
   # The standard _include_ tag.
   class IncludeTag < Tag
-    @name: untyped
+    @template_name: untyped
 
     @repeat: bool
 
@@ -2051,7 +2057,7 @@ module Liquid2
 
   # The standard _render_ tag.
   class RenderTag < Tag
-    @name: untyped
+    @template_name: untyped
 
     @repeat: bool
 
@@ -2437,5 +2443,83 @@ module Liquid2
     def initialize: ([Symbol, String?, Integer] token, String name, Array[untyped] args, Array[KeywordArgument] kwargs) -> void
 
     def render: (RenderContext context, String buffer) -> void
+  end
+end
+
+module Liquid2
+  # The _extends_ tag.
+  class ExtendsTag < Tag
+    @template_name: String
+
+    @blank: bool
+
+    attr_reader template_name: String
+
+    # @param token [[Symbol, String?, Integer]]
+    # @param parser [Parser]
+    # @return [ExtendsTag]
+    def self.parse: ([Symbol, String?, Integer] token, Parser parser) -> ExtendsTag
+
+    def initialize: ([Symbol, String?, Integer] token, String name) -> void
+
+    def render: (RenderContext context, String buffer) -> void
+
+    def stack_blocks: (RenderContext context, Template template) -> Template?
+
+    def inheritance_nodes: (RenderContext context, Template template) -> [Array[ExtendsTag], Array[BlockTag]]
+  end
+
+  # The _block_ tag.
+  class BlockTag < Tag
+    @block_name: String
+
+    @block: Block
+
+    @required: bool
+
+    @blank: bool
+
+    END_BLOCK: Set[String]
+
+    attr_reader block_name: String
+
+    attr_reader block: Block
+
+    attr_reader required: bool
+
+    # @param token [[Symbol, String?, Integer]]
+    # @param parser [Parser]
+    # @return [BlockTag]
+    def self.parse: ([Symbol, String?, Integer] token, Parser parser) -> BlockTag
+
+    def initialize: ([Symbol, String?, Integer] token, String name, Block block, required: bool) -> void
+
+    def render: (RenderContext context, String buffer) -> void
+  end
+
+  class BlockDrop
+    @token: [Symbol, String?, Integer]
+
+    @context: RenderContext
+
+    @buffer: String
+
+    @name: String
+
+    @parent: [BlockTag, bool, String, untyped?]?
+
+    attr_reader token: [Symbol, String?, Integer]
+
+    # @param token [[Symbol, String?, Integer]]
+    # @param context [RenderContext]
+    # @param name [String]
+    # @param parent [[BlockTag, bool, String, Block?]?]
+    def initialize: ([Symbol, String?, Integer] token, RenderContext context, String name, untyped parent) -> void
+
+    def to_s: () -> ::String
+
+    def key?: (untyped key) -> bool
+
+    def []: (untyped key) -> untyped
   end
 end

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -2508,7 +2508,7 @@ module Liquid2
 
     @name: String
 
-    @parent: [BlockTag, bool, String, untyped?]?
+    @parent: [BlockTag, bool, Template, untyped?]?
 
     attr_reader token: [Symbol, String?, Integer]
 

--- a/test/extends.json
+++ b/test/extends.json
@@ -1,0 +1,207 @@
+{
+  "tests": [
+    {
+      "name": "no blocks",
+      "template": "{% extends 'a' %} this should not be rendered",
+      "data": { "you": "world" },
+      "templates": {
+        "a": "Hello, {{ you }}!"
+      },
+      "result": "Hello, world!"
+    },
+    {
+      "name": "no parent block",
+      "template": "{% extends 'a' %}{% block b %}this should not be rendered{% endblock %}",
+      "data": { "you": "world" },
+      "templates": {
+        "a": "Hello, {{ you }}!"
+      },
+      "result": "Hello, world!"
+    },
+    {
+      "name": "no child block",
+      "template": "{% extends 'a' %} this should not be rendered",
+      "data": { "you": "world" },
+      "templates": {
+        "a": "Hello, {% block b %}{{ you }}!{% endblock %}"
+      },
+      "result": "Hello, world!"
+    },
+    {
+      "name": "override parent block",
+      "template": "{% extends 'a' %}{% block b %}sue{% endblock %}",
+      "data": { "you": "world" },
+      "templates": {
+        "a": "Hello, {% block b %}{{ you }}{% endblock %}!"
+      },
+      "result": "Hello, sue!"
+    },
+    {
+      "name": "render base template directly",
+      "template": "Hello, {% block b %}{{ you }}{% endblock %}!",
+      "data": { "you": "world" },
+      "result": "Hello, world!"
+    },
+    {
+      "name": "output super block",
+      "template": "{% extends a %}{% block b %}{{ block.super }} and sue{% endblock %}",
+      "data": { "you": "world" },
+      "templates": {
+        "a": "Hello, {% block b %}{{ you }}{% endblock %}!"
+      },
+      "result": "Hello, world and sue!"
+    },
+    {
+      "name": "scoped",
+      "template": "{% extends a %}{% block b %}{{ greeting }}, {{ you }}!{% endblock %}",
+      "data": {},
+      "templates": {
+        "a": "{% assign greeting = 'Hello' %}{% block b %}{% endblock %}{% assign you = 'world' %}"
+      },
+      "result": "Hello, !"
+    },
+    {
+      "name": "block scope",
+      "template": "{% extends a %}{% block b %}{{ greeting }}, {{ x }}! {% endblock %}",
+      "data": {},
+      "templates": {
+        "a": "{% assign greeting = 'Hello' %}{% for x in (1..2) %}{% block b %}{% endblock %}{% endfor %}"
+      },
+      "result": "Hello, 1! Hello, 2! "
+    },
+    {
+      "name": "multiple",
+      "template": "{% extends a %}{% block b %}Hello, {{ you }}!{% endblock %}",
+      "data": {},
+      "templates": {
+        "a": "{% extends c %}",
+        "c": "{% assign you = 'world' %}{% block b %}{% endblock %}"
+      },
+      "result": "Hello, world!"
+    },
+    {
+      "name": "nested block scoped parent variables are in scope",
+      "template": "{% extends 'some' %}{% block baz %}Hello, {{ you }} {{ other }} {{ i }}:{{ x }} {% endblock %}",
+      "result": "Hello, world banana 1:1 Hello, world banana 1:2 Hello, world banana 2:1 Hello, world banana 2:2 ",
+      "data": {},
+      "templates": {
+        "base": "{% assign you = 'world' %}{% for i in (1..2) %}{% block bar %}hello, {{ you }}!{% endblock %}{% endfor %}",
+        "some": "{% extends 'base' %}{% block bar %}{% assign other = 'banana' %}{% for x in (1..2) %}{% block baz %}{% endblock %}{% endfor %}{% endblock %}"
+      }
+    },
+    {
+      "name": "child variables are out of scope",
+      "template": "{% extends 'foo' %}{% block bar %}{% assign something = '/other' %}goodbye, {{ you }}{% assign you = 'sue' %}{% endblock %}",
+      "result": "goodbye, world",
+      "data": {},
+      "templates": {
+        "foo": "{% assign you = 'world' %}{% block bar %}{% endblock %}{{ something }}"
+      }
+    },
+    {
+      "name": "nested outer block",
+      "template": "{% extends 'foo' %}{% block bar %}Goodbye{% endblock %}",
+      "result": "Goodbye!",
+      "data": {
+        "you": "world"
+      },
+      "templates": {
+        "foo": "{% block bar %}{% block greeting %}Hello{% endblock %}, {{ you }}!{% endblock %}!"
+      }
+    },
+    {
+      "name": "override nested block",
+      "template": "{% extends 'foo' %}{% block greeting %}Goodbye{% endblock %}",
+      "result": "Goodbye, world!",
+      "data": {
+        "you": "world"
+      },
+      "templates": {
+        "foo": "{% block bar %}{% block greeting %}Hello{% endblock %}, {{ you }}!{% endblock %}"
+      }
+    },
+    {
+      "name": "super nested blocks",
+      "template": "{% extends 'foo' %}{% block bar %}{{ block.super }}!!{% endblock %}",
+      "result": "Hello, world!!!",
+      "data": {
+        "you": "world"
+      },
+      "templates": {
+        "foo": "{% block bar %}{% block greeting %}Hello{% endblock %}, {{ you }}!{% endblock %}"
+      }
+    },
+    {
+      "name": "override a parent's parent block",
+      "template": "{% extends 'bar' %}{% block greeting %}Goodbye,{% endblock %}",
+      "result": "Goodbye, world",
+      "data": {
+        "you": "world"
+      },
+      "templates": {
+        "foo": "{% block greeting %}Hello{% endblock %} {{ you }}",
+        "bar": "{% extends 'foo' %}"
+      }
+    },
+    {
+      "name": "multi-level super",
+      "template": "{% extends 'baz' %}{% block bar %}{{ block.super }}!!{% endblock %}",
+      "result": "Hello, world!**!!",
+      "data": {
+        "you": "world"
+      },
+      "templates": {
+        "foo": "{% block bar %}{% block greeting %}Hello{% endblock %}, {{ you }}!{% endblock %}",
+        "baz": "{% extends 'foo' %}{% block bar %}{{ block.super }}**{% endblock %}"
+      }
+    },
+    {
+      "name": "include an extended template",
+      "template": "{% include 'bar' %}",
+      "result": "foo bar",
+      "data": {
+        "you": "world"
+      },
+      "templates": {
+        "foo": "{% block bar %}{% block greeting %}Hello{% endblock %}, {{ you }}!{% endblock %}",
+        "bar": "{% extends 'foo' %}{% block bar %}foo bar{% endblock %}"
+      }
+    },
+    {
+      "name": "include in an overridden block",
+      "template": "{% extends 'foo' %}{% block greeting %}{% include 'bar' %}{% endblock %}",
+      "result": "I am included, world!",
+      "data": {
+        "you": "world"
+      },
+      "templates": {
+        "foo": "{% block bar %}{% block greeting %}Hello{% endblock %}, {{ you }}!{% endblock %}",
+        "bar": "I am included"
+      }
+    },
+    {
+      "name": "render an extended template",
+      "template": "{% render 'bar' %}",
+      "result": "foo bar",
+      "data": {
+        "you": "world"
+      },
+      "templates": {
+        "foo": "{% block bar %}{% block greeting %}Hello{% endblock %}, {{ you }}!{% endblock %}",
+        "bar": "{% extends 'foo' %}{% block bar %}foo bar{% endblock %}"
+      }
+    },
+    {
+      "name": "render in an overridden block",
+      "template": "{% extends 'foo' %}{% block greeting %}{% render 'bar' %}{% endblock %}",
+      "result": "I am rendered, world!",
+      "data": {
+        "you": "world"
+      },
+      "templates": {
+        "foo": "{% block bar %}{% block greeting %}Hello{% endblock %}, {{ you }}!{% endblock %}",
+        "bar": "I am rendered"
+      }
+    }
+  ]
+}

--- a/test/test_template_inheritance.rb
+++ b/test/test_template_inheritance.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "json"
+require "test_helper"
+
+class TestExtends < Minitest::Spec
+  make_my_diffs_pretty!
+
+  TEST_CASES = JSON.load_file("test/extends.json")
+
+  describe "comments" do
+    TEST_CASES["tests"].each do |test_case|
+      it test_case["name"] do
+        loader = if (templates = test_case["templates"])
+                   Liquid2::HashLoader.new(templates)
+                 end
+
+        env = Liquid2::Environment.new(loader: loader)
+        if test_case["invalid"]
+          assert_raises Liquid2::LiquidError do
+            env.parse(test_case["template"]).render(test_case["data"])
+          end
+        else
+          template = env.parse(test_case["template"])
+          if test_case["result"]
+            _(template.render(test_case["data"])).must_equal test_case["result"]
+          else
+            _(test_case["results"]).must_include template.render(test_case["data"])
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds template inheritance features with the `{% extends %}` and `{% block %}` tags.

In this example `page.liquid` inherits from `base.liquid` and overrides the `content` block. As `page.liquid` does not define a `footer` block, the footer from `base.liquid` is used.

**base.liquid**
```liquid
<body>
  <div id="content">{% block content required %}{% endblock %}</div>
  <div id="footer">{% block footer %}Default footer{% endblock %}</div>
</body>
```

**page.liquid**
```
{% extends 'base.liquid' %}
{% block content %}Hello, {{ you }}!{% endblock %}
```

With `you` set to `"world"`, rendering `page.liquid` produces this output.

```html
<body>
  <div id="content">Hello, world!</div>
  <div id="footer">Default footer</div>
</body>
```