### PR TITLE
Add the `{% with %}` tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 - Fixed error context info when raising `UndefinedError` from `StrictUndefined`.
 - Fixed parsing of compound expressions given as filter arguments.
+- Fixed sorting of string representations of floats with the `sort_numeric` filter.
 - Added `Template#docs`, which returns an array of `DocTag` instances used in a template.
 - Added implementations of the `{% macro %}` and `{% call %}` tags.
 - Added `Template#macros`, which returns arrays of `{% macro %}` and `{% call %}` tags used in a template.
 - Added template inheritance tags `{% extends %}` and `{% block %}`.
+- Added block scoped variables with the `{% with %}` tag.
 
 ## [0.1.1] - 2025-05-01
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Integer and float literals can use scientific notation, like `1.2e3` or `1e-2`.
 
 #### Extra tags and filters
 
-Liquid2 includes implementations of `{% extends %}` and `{% block %}` for template inheritance, and `{% macro %}` and `{% call %}` for defining parameterized blocks.
+Liquid2 includes implementations of `{% extends %}` and `{% block %}` for template inheritance, `{% with %}` for block scoped variables and `{% macro %}` and `{% call %}` for defining parameterized blocks.
 
 There's also built-in implementations of `sort_numeric` and `json` filters.
 

--- a/lib/liquid2/environment.rb
+++ b/lib/liquid2/environment.rb
@@ -33,6 +33,7 @@ require_relative "nodes/tags/raw"
 require_relative "nodes/tags/render"
 require_relative "nodes/tags/tablerow"
 require_relative "nodes/tags/unless"
+require_relative "nodes/tags/with"
 
 module Liquid2
   # Template parsing and rendering configuration.
@@ -221,6 +222,7 @@ module Liquid2
       @tags["render"] = RenderTag
       @tags["tablerow"] = TableRowTag
       @tags["unless"] = UnlessTag
+      @tags["with"] = WithTag
 
       register_filter("abs", Liquid2::Filters.method(:abs))
       register_filter("append", Liquid2::Filters.method(:append))

--- a/lib/liquid2/nodes/tags/with.rb
+++ b/lib/liquid2/nodes/tags/with.rb
@@ -1,3 +1,44 @@
 # frozen_string_literal: true
 
-# TODO
+require_relative "../../tag"
+
+module Liquid2
+  # The _with_ tag.
+  class WithTag < Tag
+    END_BLOCK = Set["endwith"]
+
+    # @param token [[Symbol, String?, Integer]]
+    # @param parser [Parser]
+    # @return [WithTag]
+    def self.parse(token, parser)
+      parser.next if parser.current_kind == :token_comma
+      args = parser.parse_keyword_arguments
+      parser.next if parser.current_kind == :token_comma
+      parser.carry_whitespace_control
+      parser.eat(:token_tag_end)
+      block = parser.parse_block(END_BLOCK)
+      parser.eat_empty_tag("endwith")
+      new(token, args, block)
+    end
+
+    # @param token [[Symbol, String?, Integer]]
+    # @param args [Array[KeywordArgument]]
+    # @param block [Block]
+    def initialize(token, args, block)
+      super(token)
+      @args = args
+      @block = block
+      @blank = block.blank
+    end
+
+    def render(context, buffer)
+      namespace = @args.to_h { |arg| [arg.name, context.evaluate(arg.value)] }
+      context.extend(namespace) do
+        @block.render(context, buffer)
+      end
+    end
+
+    def children(_static_context, include_partials: true) = [@block]
+    def block_scope = @args.map { |arg| Identifier.new(arg.token) }
+  end
+end

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -2527,3 +2527,31 @@ module Liquid2
     def []: (untyped key) -> untyped
   end
 end
+
+module Liquid2
+  class WithTag < Tag
+    @args: Array[KeywordArgument]
+
+    @block: Block
+
+    @blank: bool
+
+    END_BLOCK: Set[String]
+
+    # @param token [[Symbol, String?, Integer]]
+    # @param parser [Parser]
+    # @return [WithTag]
+    def self.parse: ([Symbol, String?, Integer] token, Parser parser) -> WithTag
+
+    # @param token [[Symbol, String?, Integer]]
+    # @param args [Array[KeywordArgument]]
+    # @param block [Block]
+    def initialize: ([Symbol, String?, Integer] token, Array[KeywordArgument] args, Block block) -> void
+
+    def render: (RenderContext context, String buffer) -> void
+
+    def children: (untyped _static_context, ?include_partials: bool) -> ::Array[Node]
+
+    def block_scope: () -> Array[Identifier]
+  end
+end

--- a/test/test_static_analysis.rb
+++ b/test/test_static_analysis.rb
@@ -229,5 +229,33 @@ class TestStaticAnalysis < Minitest::Test
     )
   end
 
+  def test_with
+    source = <<~LIQUID.chomp
+      {% with a: 1, b: 3.4 -%}
+      {{ a }} + {{ b }} = {{ a | plus: b }}
+      {%- endwith -%}
+      {{ a }}
+    LIQUID
+
+    assert_analysis(
+      Liquid2.parse(source),
+      locals: {},
+      globals: { "a" => [Var.new(["a"], Span.new("", 82))] },
+      variables: {
+        "a" => [
+          Var.new(["a"], Span.new("", 28)),
+          Var.new(["a"], Span.new("", 48)),
+          Var.new(["a"], Span.new("", 82))
+        ],
+        "b" => [
+          Var.new(["b"], Span.new("", 38)),
+          Var.new(["b"], Span.new("", 58))
+        ]
+      },
+      tags: { "with" => [Span.new("", 3)] },
+      filters: { "plus" => [Span.new("", 52)] }
+    )
+  end
+
   # TODO: finish me
 end

--- a/test/test_with_tag.rb
+++ b/test/test_with_tag.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestWith < Minitest::Test
+  def test_block_scoped_variables
+    source = <<~LIQUID.chomp
+      {% with a: 1, b: 3.4 -%}
+      {{ a }} + {{ b }} = {{ a | plus: b }}
+      {%- endwith -%}
+      {{ a }}
+    LIQUID
+
+    assert_equal("1 + 3.4 = 4.4", Liquid2.render(source))
+  end
+
+  def test_compound_expression
+    source = <<~LIQUID.chomp
+      {% with a: 1, b: nosuchthing or 42, c="hi" -%}
+      {{ a }} + {{ b }} = {{ a | plus: b }}
+      {%- endwith -%}
+      {{ a }}
+    LIQUID
+
+    assert_equal("1 + 42 = 43", Liquid2.render(source))
+  end
+end


### PR DESCRIPTION
Add an implementation of the `{% with %}` tag.

The `with` tag extends the template namespace with block scoped variables. These variables have the potential to temporarily shadow global variables or variables assigned with `{% assign %}` and `{% capture %}`.

```liquid
{% with p: collection.products.first %}
  {{ p.title }}
{% endwith %}

{% with a: 1, b: 3.4 %}
  {{ a }} + {{ b }} = {{ a | plus: b }}
{% endwith %}
```
