### PR TITLE
Fix `Path#to_s`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed error context info when raising `UndefinedError` from `StrictUndefined`.
 - Fixed parsing of compound expressions given as filter arguments.
 - Fixed sorting of string representations of floats with the `sort_numeric` filter.
+- Fixed the string representation of variable paths with bracket notation and nested paths.
 - Added `Template#docs`, which returns an array of `DocTag` instances used in a template.
 - Added implementations of the `{% macro %}` and `{% call %}` tags.
 - Added `Template#macros`, which returns arrays of `{% macro %}` and `{% call %}` tags used in a template.

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -1384,10 +1384,16 @@ module Liquid2
     attr_reader segments: Array[String | Integer | Path]
     attr_reader head: (String | Integer | Path)
 
+    RE_PROPERTY: ::Regexp
+
     # @param segments [Array[String | Integer | Path]]
     def initialize: ([Symbol, String?, Integer] token, Array[String | Integer | Path] segments) -> void
 
     def evaluate: (RenderContext context) -> untyped
+                
+    private
+
+    def segment_to_s: (untyped segment, ?head: bool) -> ::String
   end
 end
 

--- a/test/test_path_to_s.rb
+++ b/test/test_path_to_s.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestPathToS < Minitest::Test
+  def test_simple_variable
+    source = "{{ foo }}"
+    template = Liquid2.parse(source)
+    path = template.ast.first.expression.children.first
+
+    assert_equal("foo", path.to_s)
+  end
+
+  def test_dotted_variable
+    source = "{{ foo.bar }}"
+    template = Liquid2.parse(source)
+    path = template.ast.first.expression.children.first
+
+    assert_equal("foo.bar", path.to_s)
+  end
+
+  def test_bracket_notation_with_space
+    source = "{{ foo['b c'] }}"
+    template = Liquid2.parse(source)
+    path = template.ast.first.expression.children.first
+
+    assert_equal("foo[\"b c\"]", path.to_s)
+  end
+
+  def test_bracket_notation_with_space_at_root
+    source = "{{ ['a b'] }}"
+    template = Liquid2.parse(source)
+    path = template.ast.first.expression.children.first
+
+    assert_equal("[\"a b\"]", path.to_s)
+  end
+
+  def test_bracket_notation_with_quoted_dot_at_root
+    source = "{{ [\"a.b\"] }}"
+    template = Liquid2.parse(source)
+    path = template.ast.first.expression.children.first
+
+    assert_equal("[\"a.b\"]", path.to_s)
+  end
+
+  def test_bracket_notation_with_array_index
+    source = "{{ a[1] }}"
+    template = Liquid2.parse(source)
+    path = template.ast.first.expression.children.first
+
+    assert_equal("a[1]", path.to_s)
+  end
+
+  def test_bracket_notation_with_nested_path
+    source = "{{ a[b.c] }}"
+    template = Liquid2.parse(source)
+    path = template.ast.first.expression.children.first
+
+    assert_equal("a[b.c]", path.to_s)
+  end
+
+  def test_bracket_notation_with_deeply_nested_path
+    source = "{{ d[a[b.c]] }}"
+    template = Liquid2.parse(source)
+    path = template.ast.first.expression.children.first
+
+    assert_equal("d[a[b.c]]", path.to_s)
+  end
+
+  def test_bracket_notation_with_nested_path_at_root
+    source = "{{ [a.b] }}"
+    template = Liquid2.parse(source)
+    path = template.ast.first.expression.children.first
+
+    assert_equal("[a.b]", path.to_s)
+  end
+end


### PR DESCRIPTION
This PR fixes the string representation of `Liquid2::Path` when the path uses bracket notation and nested paths.