### PR TITLE
Some minor performance improvements

### DIFF
--- a/lib/liquid2/context.rb
+++ b/lib/liquid2/context.rb
@@ -71,7 +71,6 @@ module Liquid2
 
       # Namespaces are searched from right to left. When a RenderContext is extended, the
       # temporary namespace is pushed to the end of this queue.
-      # TODO: exclude @globals if globals is empty
       @scope = ReadOnlyChainHash.new(@counters, BUILT_IN, @globals, @locals)
 
       # A namespace supporting stateful tags, such as `cycle` and `increment`.

--- a/lib/liquid2/filter.rb
+++ b/lib/liquid2/filter.rb
@@ -63,8 +63,7 @@ module Liquid2
     end
 
     # Cast _obj_ to a  date and time. Return `nil` if casting fails.
-    #
-    # TODO: This was copied from Shopify/liquid. Include their license and copyright.
+    # NOTE: This was copied from Shopify/liquid.
     def self.to_date(obj)
       return obj if obj.respond_to?(:strftime)
 

--- a/lib/liquid2/filters/array.rb
+++ b/lib/liquid2/filters/array.rb
@@ -29,7 +29,6 @@ module Liquid2
       when :undefined
         left.compact
       else
-        # TODO: stringify key?
         left.reject do |item|
           item.respond_to?(:fetch) ? item.fetch(key, nil).nil? : true
         end

--- a/lib/liquid2/parser.rb
+++ b/lib/liquid2/parser.rb
@@ -233,7 +233,6 @@ module Liquid2
       left = parse_primary
       left = parse_array_literal(left) if current_kind == :token_comma
       filters = parse_filters if current_kind == :token_pipe
-      filters ||= [] # : Array[Filter]
       expr = FilteredExpression.new(token, left, filters)
 
       if current_kind == :token_if
@@ -861,7 +860,7 @@ module Liquid2
 
       unless current_kind == :token_colon || !TERMINATE_FILTER.member?(current_kind)
         # No arguments
-        return Filter.new(name, name[1] || raise, []) # TODO: optimize
+        return Filter.new(name, name[1] || raise, nil)
       end
 
       @pos += 1 # token_colon

--- a/lib/liquid2/static_analysis.rb
+++ b/lib/liquid2/static_analysis.rb
@@ -231,7 +231,7 @@ module Liquid2
     def self.extract_filters(expression, template_name)
       filters = [] # : Array[[String, Span]]
 
-      if expression.is_a?(Liquid2::FilteredExpression)
+      if expression.is_a?(Liquid2::FilteredExpression) && !expression.filters.nil?
         expression.filters.each do |filter|
           filters << [filter.name, Span.new(template_name, filter.token.last)]
         end

--- a/lib/liquid2/template.rb
+++ b/lib/liquid2/template.rb
@@ -43,7 +43,6 @@ module Liquid2
     end
 
     def render_with_context(context, buffer, partial: false, block_scope: false, namespace: nil)
-      # TODO: don't extend if namespace is nil
       context.extend(namespace || {}) do
         index = 0
         while (node = @ast[index])
@@ -78,8 +77,7 @@ module Liquid2
 
     # Merge template globals with another namespace.
     def make_globals(namespace)
-      # TODO: optimize
-      @globals.merge(@overlay || {}, namespace || {})
+      @globals.merge(@overlay, namespace || {})
     end
 
     # Return `false` if this template is stale and needs to be loaded again.

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -864,7 +864,6 @@ module Liquid2
 
     attr_accessor interrupts: Array[Symbol]
 
-
     BUILT_IN: BuiltIn
 
     # @param template [Template]
@@ -1213,11 +1212,11 @@ module Liquid2
   class FilteredExpression < Expression
     @left: Expression
 
-    @filters: Array[Filter]
+    @filters: Array[Filter]?
 
-    attr_reader filters: Array[Filter]
+    attr_reader filters: Array[Filter]?
 
-    def initialize: ([Symbol, String?, Integer] token, untyped left, Array[Filter] filters) -> void
+    def initialize: ([Symbol, String?, Integer] token, untyped left, Array[Filter]? filters) -> void
 
     def evaluate: (RenderContext context) -> untyped
   end
@@ -1250,25 +1249,17 @@ module Liquid2
   class Filter < Expression
     @name: String
 
-    @args: Array[untyped]
+    @args: Array[untyped]?
 
     attr_reader name: String 
 
-    attr_reader args: Array[untyped] 
+    attr_reader args: Array[untyped]?
 
     # @param name [Token]
     # @param args [Array[Expression]]
-    def initialize: ([Symbol, String?, Integer] token, String name, Array[untyped] args) -> void
+    def initialize: ([Symbol, String?, Integer] token, String name, Array[untyped]? args) -> void
 
     def evaluate: (untyped left, RenderContext context) -> untyped
-
-    private
-
-    # @param context [RenderContext]
-    # @return [positional arguments, keyword arguments] An array with two elements.
-    #   The first is an array of evaluates positional arguments. The second is a hash
-    #   of keyword names to evaluated keyword values.
-    def evaluate_args: (RenderContext context) -> [Array[untyped], Hash[Symbol, untyped]]
   end
 end
 


### PR DESCRIPTION
**Before**
```
james@Jamess-Mac-mini ruby-liquid2 % bundle exec ruby performance/benchmark.rb 
ruby 3.4.3 (2025-04-14 revision d0b7e5b6a0) +PRISM [arm64-darwin24]
Warming up --------------------------------------
        parse (002):   293.000 i/100ms
       render (002):     1.113k i/100ms
         both (002):   219.000 i/100ms
Calculating -------------------------------------
        parse (002):      2.854k (± 0.5%) i/s  (350.38 μs/i) -     14.357k in   5.030505s
       render (002):     11.040k (± 0.6%) i/s   (90.58 μs/i) -     55.650k in   5.041144s
         both (002):      2.218k (± 1.0%) i/s  (450.90 μs/i) -     11.169k in   5.036595s
```

**After**
```
james@Jamess-Mac-mini ruby-liquid2 % bundle exec ruby performance/benchmark.rb 
ruby 3.4.3 (2025-04-14 revision d0b7e5b6a0) +PRISM [arm64-darwin24]
Warming up --------------------------------------
        parse (002):   312.000 i/100ms
       render (002):     1.160k i/100ms
         both (002):   232.000 i/100ms
Calculating -------------------------------------
        parse (002):      3.062k (± 1.2%) i/s  (326.57 μs/i) -     15.600k in   5.095298s
       render (002):     11.720k (± 1.2%) i/s   (85.32 μs/i) -     59.160k in   5.048413s
         both (002):      2.342k (± 1.3%) i/s  (427.00 μs/i) -     11.832k in   5.053072s
```

**Before (YJIT)**
```
james@Jamess-Mac-mini ruby-liquid2 % bundle exec ruby --yjit performance/benchmark.rb
ruby 3.4.3 (2025-04-14 revision d0b7e5b6a0) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
        parse (002):   476.000 i/100ms
       render (002):     2.755k i/100ms
         both (002):   401.000 i/100ms
Calculating -------------------------------------
        parse (002):      4.681k (± 1.3%) i/s  (213.64 μs/i) -     23.800k in   5.085559s
       render (002):     27.512k (± 0.9%) i/s   (36.35 μs/i) -    137.750k in   5.007297s
         both (002):      3.949k (± 1.3%) i/s  (253.22 μs/i) -     20.050k in   5.077941s
```

**After (YJIT)**
```
ruby 3.4.3 (2025-04-14 revision d0b7e5b6a0) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
        parse (002):   477.000 i/100ms
       render (002):     2.947k i/100ms
         both (002):   406.000 i/100ms
Calculating -------------------------------------
        parse (002):      4.755k (± 0.2%) i/s  (210.30 μs/i) -     23.850k in   5.015654s
       render (002):     29.242k (± 0.3%) i/s   (34.20 μs/i) -    147.350k in   5.038968s
         both (002):      4.051k (± 0.2%) i/s  (246.87 μs/i) -     20.300k in   5.011524s
```