### PR TITLE
Arithmetic operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+
+- Added support for arithmetic operators `+`, `-`, `*`, `/`, `%` and `**`.
+
 ## [0.2.0] - 25-05-12
 
 - Fixed error context info when raising `UndefinedError` from `StrictUndefined`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [unreleased]
 
-- Added support for arithmetic operators `+`, `-`, `*`, `/`, `%` and `**`.
+- Added support for arithmetic operators `+`, `-`, `*`, `/`, `%` and `**`. These operators are disabled by default. Enable them by passing `arithmetic_operators: true` to a new `Liquid2::Environment`.
 
 ## [0.2.0] - 25-05-12
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ Here we use `~` to remove the newline after the opening `for` tag, but preserve 
 </ul>
 ```
 
+#### Arithmetic operators
+
+Arithmetic operators `+`, `-`, `*`, `/`, `%` and `**` are disabled by default. Enable them by passing `arithmetic_operators: true` to a new [`Liquid2::Environment`](https://github.com/jg-rp/ruby-liquid2/blob/main/lib/liquid2/environment.rb).
+
 #### Scientific notation
 
 Integer and float literals can use scientific notation, like `1.2e3` or `1e-2`.

--- a/lib/liquid2/environment.rb
+++ b/lib/liquid2/environment.rb
@@ -45,7 +45,7 @@ module Liquid2
   class Environment
     attr_reader :tags, :local_namespace_limit, :context_depth_limit, :loop_iteration_limit,
                 :output_stream_limit, :filters, :suppress_blank_control_flow_blocks,
-                :shorthand_indexes, :falsy_undefined
+                :shorthand_indexes, :falsy_undefined, :arithmetic_operators
 
     # @param context_depth_limit [Integer] The maximum number of times a render context can
     #   be extended or copied before a `Liquid2::LiquidResourceLimitError`` is raised.
@@ -68,6 +68,7 @@ module Liquid2
     # @param undefined [singleton(Liquid2::Undefined)] A singleton returning an instance of
     #   `Liquid2::Undefined`, which is used to represent template variables that don't exist.
     def initialize(
+      arithmetic_operators: false,
       context_depth_limit: 30,
       globals: nil,
       loader: nil,
@@ -86,6 +87,10 @@ module Liquid2
       # along with a flag to indicate if the callable accepts a `context`
       # keyword argument.
       @filters = {}
+
+      # When `true`, arithmetic operators `+`, `-`, `*`, `/`, `%` and `**` are enabled.
+      # Defaults to `false`.
+      @arithmetic_operators = arithmetic_operators
 
       # The maximum number of times a render context can be extended or copied before
       # a Liquid2::LiquidResourceLimitError is raised.

--- a/lib/liquid2/expressions/arithmetic.rb
+++ b/lib/liquid2/expressions/arithmetic.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require_relative "blank"
+require_relative "../expression"
+
+module Liquid2 # :nodoc:
+  # Base class for all arithmetic expressions.
+  class ArithmeticExpression < Expression
+    # @param left [Expression]
+    # @param right [Expression]
+    def initialize(token, left, right)
+      super(token)
+      @left = left
+      @right = right
+    end
+
+    def children = [@left, @right]
+
+    protected
+
+    def inner_evaluate(context)
+      left = context.evaluate(@left)
+      right = context.evaluate(@right)
+      left = left.to_liquid(context) if left.respond_to?(:to_liquid)
+      right = right.to_liquid(context) if right.respond_to?(:to_liquid)
+      [Liquid2::Filters.to_decimal(left), Liquid2::Filters.to_decimal(right)]
+    end
+  end
+
+  # Infix addition
+  class Plus < ArithmeticExpression
+    def evaluate(context)
+      left, right = inner_evaluate(context)
+      left + right
+    end
+  end
+
+  # Infix subtraction
+  class Minus < ArithmeticExpression
+    def evaluate(context)
+      left, right = inner_evaluate(context)
+      left - right
+    end
+  end
+
+  # Infix multiplication
+  class Times < ArithmeticExpression
+    def evaluate(context)
+      left, right = inner_evaluate(context)
+      left * right
+    end
+  end
+
+  # Infix division
+  class Divide < ArithmeticExpression
+    def evaluate(context)
+      left, right = inner_evaluate(context)
+      # TODO: handle divide by zero
+      left / right
+    end
+  end
+
+  # Infix modulo
+  class Modulo < ArithmeticExpression
+    def evaluate(context)
+      left, right = inner_evaluate(context)
+      # TODO: handle divide by zero
+      left % right
+    end
+  end
+
+  # Infix exponentiation
+  class Pow < ArithmeticExpression
+    def evaluate(context)
+      left, right = inner_evaluate(context)
+      left**right
+    end
+  end
+end

--- a/lib/liquid2/expressions/arithmetic.rb
+++ b/lib/liquid2/expressions/arithmetic.rb
@@ -55,8 +55,9 @@ module Liquid2 # :nodoc:
   class Divide < ArithmeticExpression
     def evaluate(context)
       left, right = inner_evaluate(context)
-      # TODO: handle divide by zero
       left / right
+    rescue ZeroDivisionError => e
+      raise LiquidTypeError.new(e.message, nil)
     end
   end
 
@@ -64,8 +65,9 @@ module Liquid2 # :nodoc:
   class Modulo < ArithmeticExpression
     def evaluate(context)
       left, right = inner_evaluate(context)
-      # TODO: handle divide by zero
       left % right
+    rescue ZeroDivisionError => e
+      raise LiquidTypeError.new(e.message, nil)
     end
   end
 

--- a/lib/liquid2/expressions/relational.rb
+++ b/lib/liquid2/expressions/relational.rb
@@ -4,7 +4,7 @@ require_relative "blank"
 require_relative "../expression"
 
 module Liquid2 # :nodoc:
-  # Base for comparison expressions.
+  # Base class for all comparison expressions.
   class ComparisonExpression < Expression
     # @param left [Expression]
     # @param right [Expression]

--- a/lib/liquid2/parser.rb
+++ b/lib/liquid2/parser.rb
@@ -859,20 +859,28 @@ module Liquid2
         LogicalAnd.new(op_token, left, right)
       when :token_or
         LogicalOr.new(op_token, left, right)
-      when :token_plus
-        Plus.new(op_token, left, right)
-      when :token_minus
-        Minus.new(op_token, left, right)
-      when :token_times
-        Times.new(op_token, left, right)
-      when :token_divide
-        Divide.new(op_token, left, right)
-      when :token_mod
-        Modulo.new(op_token, left, right)
-      when :token_pow
-        Pow.new(op_token, left, right)
       else
-        raise LiquidSyntaxError.new("unexpected infix operator, #{op_token[1]}", op_token)
+        unless @env.arithmetic_operators
+          raise LiquidSyntaxError.new("unexpected infix operator, #{op_token[1]}",
+                                      op_token)
+        end
+
+        case op_token.first
+        when :token_plus
+          Plus.new(op_token, left, right)
+        when :token_minus
+          Minus.new(op_token, left, right)
+        when :token_times
+          Times.new(op_token, left, right)
+        when :token_divide
+          Divide.new(op_token, left, right)
+        when :token_mod
+          Modulo.new(op_token, left, right)
+        when :token_pow
+          Pow.new(op_token, left, right)
+        else
+          raise LiquidSyntaxError.new("unexpected infix operator, #{op_token[1]}", op_token)
+        end
       end
     end
 

--- a/lib/liquid2/parser.rb
+++ b/lib/liquid2/parser.rb
@@ -7,6 +7,7 @@ require_relative "node"
 require_relative "nodes/comment"
 require_relative "nodes/output"
 require_relative "expressions/arguments"
+require_relative "expressions/arithmetic"
 require_relative "expressions/array"
 require_relative "expressions/blank"
 require_relative "expressions/boolean"
@@ -536,6 +537,9 @@ module Liquid2
       RELATIONAL = 5
       MEMBERSHIP = 6
       PREFIX = 7
+      ADD_SUB = 8
+      MUL_DIV = 9
+      POW = 10
     end
 
     PRECEDENCES = {
@@ -551,7 +555,14 @@ module Liquid2
       token_ne: Precedence::RELATIONAL,
       token_lg: Precedence::RELATIONAL,
       token_le: Precedence::RELATIONAL,
-      token_ge: Precedence::RELATIONAL
+      token_ge: Precedence::RELATIONAL,
+      token_plus: Precedence::ADD_SUB,
+      token_minus: Precedence::ADD_SUB,
+      token_times: Precedence::MUL_DIV,
+      token_divide: Precedence::MUL_DIV,
+      token_floor_div: Precedence::MUL_DIV,
+      token_mod: Precedence::MUL_DIV,
+      token_pow: Precedence::POW
     }.freeze
 
     BINARY_OPERATORS = Set[
@@ -565,7 +576,14 @@ module Liquid2
       :token_contains,
       :token_in,
       :token_and,
-      :token_or
+      :token_or,
+      :token_plus,
+      :token_minus,
+      :token_times,
+      :token_divide,
+      :token_floor_div,
+      :token_mod,
+      :token_pow
     ]
 
     TERMINATE_EXPRESSION = Set[
@@ -841,6 +859,18 @@ module Liquid2
         LogicalAnd.new(op_token, left, right)
       when :token_or
         LogicalOr.new(op_token, left, right)
+      when :token_plus
+        Plus.new(op_token, left, right)
+      when :token_minus
+        Minus.new(op_token, left, right)
+      when :token_times
+        Times.new(op_token, left, right)
+      when :token_divide
+        Divide.new(op_token, left, right)
+      when :token_mod
+        Modulo.new(op_token, left, right)
+      when :token_pow
+        Pow.new(op_token, left, right)
       else
         raise LiquidSyntaxError.new("unexpected infix operator, #{op_token[1]}", op_token)
       end

--- a/lib/liquid2/scanner.rb
+++ b/lib/liquid2/scanner.rb
@@ -16,7 +16,7 @@ module Liquid2
     RE_WORD = /[\u0080-\uFFFFa-zA-Z_][\u0080-\uFFFFa-zA-Z0-9_-]*/
     RE_INT  = /-?\d+(?:[eE]\+?\d+)?/
     RE_FLOAT = /((?:-?\d+\.\d+(?:[eE][+-]?\d+)?)|(-?\d+[eE]-\d+))/
-    RE_PUNCTUATION = /\?|\[|\]|\|{1,2}|\.{1,2}|,|:|\(|\)|[<>=!]+/
+    RE_PUNCTUATION = %r{\?|\[|\]|\|{1,2}|\.{1,2}|,|:|\(|\)|[<>=!]+|[+\-%*/]+(?![\}%])}
     RE_SINGLE_QUOTE_STRING_SPECIAL = /[\\'\$]/
     RE_DOUBLE_QUOTE_STRING_SPECIAL = /[\\"\$]/
 
@@ -58,7 +58,14 @@ module Liquid2
       ">=" => :token_ge,
       "==" => :token_eq,
       "!=" => :token_ne,
-      "=>" => :token_arrow
+      "=>" => :token_arrow,
+      "+" => :token_plus,
+      "-" => :token_minus,
+      "%" => :token_mod,
+      "*" => :token_times,
+      "/" => :token_divide,
+      "//" => :token_floor_div,
+      "**" => :token_pow
     }.freeze
 
     def self.tokenize(source, scanner)

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -84,6 +84,8 @@ module Liquid2
 
     @scanner: StringScanner
 
+    @arithmetic_operators: bool
+
     attr_reader tags: Hash[String, _Tag]
 
     attr_reader local_namespace_limit: Integer?
@@ -101,6 +103,8 @@ module Liquid2
     attr_reader shorthand_indexes: bool
 
     attr_reader falsy_undefined: bool
+
+    attr_reader arithmetic_operators: bool
 
     def initialize: (?context_depth_limit: ::Integer, ?globals: Hash[String, untyped]?, ?loader: TemplateLoader?, ?local_namespace_limit: Integer?, ?loop_iteration_limit: Integer?, ?output_stream_limit: Integer?, ?shorthand_indexes: bool, ?suppress_blank_control_flow_blocks: bool, ?undefined: singleton(Undefined), ?falsy_undefined: bool) -> void
 

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -375,6 +375,12 @@ module Liquid2
       MEMBERSHIP: 6
 
       PREFIX: 7
+
+      ADD_SUB: 8
+
+      MUL_DIV: 9
+      
+      POW: 10
     end
 
     PRECEDENCES: Hash[Symbol, Integer]
@@ -2550,5 +2556,52 @@ module Liquid2
     def children: (untyped _static_context, ?include_partials: bool) -> ::Array[Node]
 
     def block_scope: () -> Array[Identifier]
+  end
+end
+
+module Liquid2
+  # Base class for all arithmetic expressions.
+  class ArithmeticExpression < Expression
+    @left: untyped
+
+    @right: untyped
+
+    # @param left [Expression]
+    # @param right [Expression]
+    def initialize: ([Symbol, String?, Integer] token, untyped left, untyped right) -> void
+
+    def children: () -> ::Array[untyped]
+
+    def inner_evaluate: (untyped context) -> ::Array[untyped]
+  end
+
+  # Infix addition
+  class Plus < ArithmeticExpression
+    def evaluate: (RenderContext context) -> untyped
+  end
+
+  # Infix subtraction
+  class Minus < ArithmeticExpression
+    def evaluate: (RenderContext context) -> untyped
+  end
+
+  # Infix multiplication
+  class Times < ArithmeticExpression
+    def evaluate: (RenderContext context) -> untyped
+  end
+
+  # Infix division
+  class Divide < ArithmeticExpression
+    def evaluate: (RenderContext context) -> untyped
+  end
+
+  # Infix modulo
+  class Modulo < ArithmeticExpression
+    def evaluate: (RenderContext context) -> untyped
+  end
+
+  # Infix exponentiation
+  class Pow < ArithmeticExpression
+    def evaluate: (RenderContext context) -> untyped
   end
 end

--- a/test/arithmetic.json
+++ b/test/arithmetic.json
@@ -1,0 +1,274 @@
+{
+  "tests": [
+    {
+      "name": "divide, integers",
+      "template": "{{ 10 / 2 }}",
+      "result": "5"
+    },
+    {
+      "name": "divide, integer and float",
+      "template": "{{ 10 / 2.0 }}",
+      "result": "5.0"
+    },
+    {
+      "name": "divide, integer floor division",
+      "template": "{{ 9 / 2 }}",
+      "result": "4"
+    },
+    {
+      "name": "divide, float and integer",
+      "template": "{{ 9.0 / 2 }}",
+      "result": "4.5"
+    },
+    {
+      "name": "divide, integer and float floor division",
+      "template": "{{ 20 / 7.0 }}",
+      "result": "2.857142857142857"
+    },
+    {
+      "name": "divide, integer as strings",
+      "template": "{{ \"10\" / \"2\" }}",
+      "result": "5"
+    },
+    {
+      "name": "divide, non numeric string left",
+      "template": "{{ \"foo\" / \"2\" }}",
+      "result": "0"
+    },
+    {
+      "name": "divide, non numeric string right",
+      "template": "{{ \"10\" / \"foo\" }}",
+      "invalid": true
+    },
+    {
+      "name": "divide, undefined left",
+      "template": "{{ nosuchthing / 2 }}",
+      "result": "0"
+    },
+    {
+      "name": "divide, undefined right",
+      "template": "{{ 10 / nosuchthing }}",
+      "invalid": true
+    },
+    {
+      "name": "divide, by zero",
+      "template": "{{ 10 / 0 }}",
+      "invalid": true
+    },
+    {
+      "name": "minus, integers",
+      "template": "{{ 10 - 2 }}",
+      "result": "8"
+    },
+    {
+      "name": "minus, integer and float",
+      "template": "{{ 10 - 2.0 }}",
+      "result": "8.0"
+    },
+    {
+      "name": "minus, floats",
+      "template": "{{ 10.1 - 2.2 }}",
+      "result": "7.9"
+    },
+    {
+      "name": "minus, floats as stings",
+      "template": "{{ \"10.1\" - \"2.2\" }}",
+      "result": "7.9"
+    },
+    {
+      "name": "minus, non numeric string left",
+      "template": "{{ \"foo\" - \"2.0\" }}",
+      "result": "-2.0"
+    },
+    {
+      "name": "minus, non numeric string right",
+      "template": "{{ \"10\" - \"foo\" }}",
+      "result": "10"
+    },
+    {
+      "name": "minus, undefined left",
+      "template": "{{ nosuchthing - 2 }}",
+      "result": "-2"
+    },
+    {
+      "name": "minus, undefined right",
+      "template": "{{ 10 - nosuchthing }}",
+      "result": "10"
+    },
+    {
+      "name": "modulo, integers",
+      "template": "{{ 10 % 3 }}",
+      "result": "1"
+    },
+    {
+      "name": "modulo, integer and float",
+      "template": "{{ 10 % 3.0 }}",
+      "result": "1.0"
+    },
+    {
+      "name": "modulo, float and integer",
+      "template": "{{ 10.0 % 3 }}",
+      "result": "1.0"
+    },
+    {
+      "name": "modulo, floats",
+      "template": "{{ 10.1 % 7.0 }}",
+      "result": "3.1"
+    },
+    {
+      "name": "modulo, floats as strings",
+      "template": "{{ \"10.1\" % \"7.0\" }}",
+      "result": "3.1"
+    },
+    {
+      "name": "modulo, non numeric string left",
+      "template": "{{ \"foo\" % \"7.0\" }}",
+      "result": "0.0"
+    },
+    {
+      "name": "modulo, non numeric string right",
+      "template": "{{ 10 % \"foo\" }}",
+      "invalid": true
+    },
+    {
+      "name": "modulo, undefined left",
+      "template": "{{ nosuchthing % 2 }}",
+      "result": "0"
+    },
+    {
+      "name": "modulo, undefined right",
+      "template": "{{ 10 % nosuchhting }}",
+      "invalid": true
+    },
+    {
+      "name": "plus, integers",
+      "template": "{{ 10 + 2 }}",
+      "result": "12"
+    },
+    {
+      "name": "plus, integer and float",
+      "template": "{{ 10 + 2.0 }}",
+      "result": "12.0"
+    },
+    {
+      "name": "plus, floats",
+      "template": "{{ 10.1 + 2.2 }}",
+      "result": "12.3"
+    },
+    {
+      "name": "plus, floats as stings",
+      "template": "{{ \"10.1\" + \"2.2\" }}",
+      "result": "12.3"
+    },
+    {
+      "name": "plus, non numeric string left",
+      "template": "{{ \"foo\" + \"2.0\" }}",
+      "result": "2.0"
+    },
+    {
+      "name": "plus, non numeric string right",
+      "template": "{{ \"10\" + \"foo\" }}",
+      "result": "10"
+    },
+    {
+      "name": "plus, undefined left",
+      "template": "{{ nosuchthing + 2 }}",
+      "result": "2"
+    },
+    {
+      "name": "plus, undefined right",
+      "template": "{{ 10 + nosuchthing }}",
+      "result": "10"
+    },
+    {
+      "name": "times, integers",
+      "template": "{{ 10 * 2 }}",
+      "result": "20"
+    },
+    {
+      "name": "times, integer and float",
+      "template": "{{ 10 * 2.0 }}",
+      "result": "20.0"
+    },
+    {
+      "name": "times, floats",
+      "template": "{{ 5 * 2.1 }}",
+      "result": "10.5"
+    },
+    {
+      "name": "times, floats as stings",
+      "template": "{{ \"5\" * \"2.1\" }}",
+      "result": "10.5"
+    },
+    {
+      "name": "times, non numeric string left",
+      "template": "{{ \"foo\" * \"2.0\" }}",
+      "result": "0.0"
+    },
+    {
+      "name": "times, non numeric string right",
+      "template": "{{ \"10\" * \"foo\" }}",
+      "result": "0"
+    },
+    {
+      "name": "times, undefined left",
+      "template": "{{ nosuchthing * 2 }}",
+      "result": "0"
+    },
+    {
+      "name": "times, undefined right",
+      "template": "{{ 10 * nosuchthing }}",
+      "result": "0"
+    },
+    {
+      "name": "pow, integers",
+      "template": "{{ 2 ** 3 }}",
+      "result": "8"
+    },
+    {
+      "name": "pow, floats",
+      "template": "{{ 2.0 ** 3.0 }}",
+      "result": "8.0"
+    },
+    {
+      "name": "pow, float and int",
+      "template": "{{ 2.0 ** 3 }}",
+      "result": "8.0"
+    },
+    {
+      "name": "pow, int and float",
+      "template": "{{ 2 ** 3.0 }}",
+      "result": "8.0"
+    },
+    {
+      "name": "times has higher precedence than plus",
+      "template": "{{ 2 + 3 * 4 }}",
+      "result": "14"
+    },
+    {
+      "name": "group terms so plus is evaluated before times",
+      "template": "{{ (2 + 3) * 4 }}",
+      "result": "20"
+    },
+    {
+      "name": "divide has higher precedence than minus",
+      "template": "{{ 4 - 3 / 2.0 }}",
+      "result": "2.5"
+    },
+    {
+      "name": "group terms so minus is evaluated before divide",
+      "template": "{{ (4 - 3) / 2.0 }}",
+      "result": "0.5"
+    },
+    {
+      "name": "pow has higher priority than times",
+      "template": "{{ 2 * 2**3 }}",
+      "result": "16"
+    },
+    {
+      "name": "group terms to times is evaluated before pow",
+      "template": "{{ (2 * 2)**3 }}",
+      "result": "64"
+    }
+  ]
+}

--- a/test/test_arithmetic_operators.rb
+++ b/test/test_arithmetic_operators.rb
@@ -15,7 +15,8 @@ class TestArithmeticOperators < Minitest::Spec
                    Liquid2::HashLoader.new(templates)
                  end
 
-        env = Liquid2::Environment.new(loader: loader)
+        env = Liquid2::Environment.new(loader: loader, arithmetic_operators: true)
+
         if test_case["invalid"]
           assert_raises Liquid2::LiquidError do
             env.parse(test_case["template"]).render(test_case["data"])

--- a/test/test_arithmetic_operators.rb
+++ b/test/test_arithmetic_operators.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "json"
+require "test_helper"
+
+class TestArithmeticOperators < Minitest::Spec
+  make_my_diffs_pretty!
+
+  TEST_CASES = JSON.load_file("test/arithmetic.json")
+
+  describe "arithmetic expressions" do
+    TEST_CASES["tests"].each do |test_case|
+      it test_case["name"] do
+        loader = if (templates = test_case["templates"])
+                   Liquid2::HashLoader.new(templates)
+                 end
+
+        env = Liquid2::Environment.new(loader: loader)
+        if test_case["invalid"]
+          assert_raises Liquid2::LiquidError do
+            env.parse(test_case["template"]).render(test_case["data"])
+          end
+        else
+          template = env.parse(test_case["template"])
+          if test_case["result"]
+            _(template.render(test_case["data"])).must_equal test_case["result"]
+          else
+            _(test_case["results"]).must_include template.render(test_case["data"])
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/test_compliance.rb
+++ b/test/test_compliance.rb
@@ -67,7 +67,10 @@ class TestCompliance < Minitest::Spec
     "tags, if, logical operators are right associative",
     "tags, if, not is not a valid operator",
     "tags, liquid, liquid tag in liquid tag",
-    "tags, liquid, nested liquid in liquid tag"
+    "tags, liquid, nested liquid in liquid tag",
+    "illegal, no subtraction operator",
+    "illegal, no multiplication operator",
+    "illegal, no addition operator"
   ].freeze
   # rubocop:enable Layout/LineLength
 

--- a/test/test_compliance.rb
+++ b/test/test_compliance.rb
@@ -67,10 +67,7 @@ class TestCompliance < Minitest::Spec
     "tags, if, logical operators are right associative",
     "tags, if, not is not a valid operator",
     "tags, liquid, liquid tag in liquid tag",
-    "tags, liquid, nested liquid in liquid tag",
-    "illegal, no subtraction operator",
-    "illegal, no multiplication operator",
-    "illegal, no addition operator"
+    "tags, liquid, nested liquid in liquid tag"
   ].freeze
   # rubocop:enable Layout/LineLength
 

--- a/test/test_scanner.rb
+++ b/test/test_scanner.rb
@@ -147,6 +147,83 @@ class TestTokenize < Minitest::Spec
         [:token_output_end, nil, 54],
         [:token_other, "!", 56]
       ]
+    },
+    {
+      name: "output, plus operator",
+      source: "{{ 42 + 3 }}",
+      want: [
+        [:token_output_start, nil, 0],
+        [:token_int, "42", 3],
+        [:token_plus, "+", 6],
+        [:token_int, "3", 8],
+        [:token_output_end, nil, 10]
+      ]
+    },
+    {
+      name: "output, minus operator",
+      source: "{{ 42 - 3 }}",
+      want: [
+        [:token_output_start, nil, 0],
+        [:token_int, "42", 3],
+        [:token_minus, "-", 6],
+        [:token_int, "3", 8],
+        [:token_output_end, nil, 10]
+      ]
+    },
+    {
+      name: "output, modulo operator",
+      source: "{{ 42 % 3 }}",
+      want: [
+        [:token_output_start, nil, 0],
+        [:token_int, "42", 3],
+        [:token_mod, "%", 6],
+        [:token_int, "3", 8],
+        [:token_output_end, nil, 10]
+      ]
+    },
+    {
+      name: "output, divide operator",
+      source: "{{ 42 / 3 }}",
+      want: [
+        [:token_output_start, nil, 0],
+        [:token_int, "42", 3],
+        [:token_divide, "/", 6],
+        [:token_int, "3", 8],
+        [:token_output_end, nil, 10]
+      ]
+    },
+    {
+      name: "output, times operator",
+      source: "{{ 42 * 3 }}",
+      want: [
+        [:token_output_start, nil, 0],
+        [:token_int, "42", 3],
+        [:token_times, "*", 6],
+        [:token_int, "3", 8],
+        [:token_output_end, nil, 10]
+      ]
+    },
+    {
+      name: "output, power operator",
+      source: "{{ 42 ** 3 }}",
+      want: [
+        [:token_output_start, nil, 0],
+        [:token_int, "42", 3],
+        [:token_pow, "**", 6],
+        [:token_int, "3", 9],
+        [:token_output_end, nil, 11]
+      ]
+    },
+    {
+      name: "output, floor div operator",
+      source: "{{ 42 // 3 }}",
+      want: [
+        [:token_output_start, nil, 0],
+        [:token_int, "42", 3],
+        [:token_floor_div, "//", 6],
+        [:token_int, "3", 9],
+        [:token_output_end, nil, 11]
+      ]
     }
   ].freeze
 

--- a/test/test_syntax_errors.rb
+++ b/test/test_syntax_errors.rb
@@ -104,14 +104,14 @@ class TestLiquidSyntaxErrors < Minitest::Test
 
   def test_hyphen_string
     source = "{{ -'foo' }}"
-    message = "unexpected token_unknown"
+    message = "unexpected token_minus"
     error = assert_raises(Liquid2::LiquidSyntaxError) { Liquid2.render(source) }
     assert_equal(message, error.message)
   end
 
   def test_unknown_prefix_operator
     source = "{{ +5 }}"
-    message = "unexpected token_unknown"
+    message = "unexpected token_plus"
     error = assert_raises(Liquid2::LiquidSyntaxError) { Liquid2.render(source) }
     assert_equal(message, error.message)
   end


### PR DESCRIPTION
This PR adds support for arithmetic operators `+`, `-`, `*`, `/`, `%` and `**`.

These operators are disabled by default. Enable them by passing `arithmetic_operators: true` when constructing a new `Liquid2::Environment`.

By default, arithmetic operators follow the same semantics as their filter equivalents and follow the usual operator precedence rules. I intend to add an option to change `/` and `divide_by` to **not** do integer division, and enable `//` and `floor_divide_by`. This will probably be done in a different pull request.

Yet another option to return `undefined` or infinity instead of raising a `ZeroDivisionError` or `LiquidTypeError` when dividing by zero might be good too.