### PR TITLE
Add support for unary `+` and `-` operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [unreleased]
 
-- Added support for arithmetic operators `+`, `-`, `*`, `/`, `%` and `**`. These operators are disabled by default. Enable them by passing `arithmetic_operators: true` to a new `Liquid2::Environment`.
+- Added support for arithmetic infix operators `+`, `-`, `*`, `/`, `%` and `**`, and prefix operators `+` and `-`. These operators are disabled by default. Enable them by passing `arithmetic_operators: true` to a new `Liquid2::Environment`.
 
 ## [0.2.0] - 25-05-12
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Here we use `~` to remove the newline after the opening `for` tag, but preserve 
 
 #### Arithmetic operators
 
-Arithmetic operators `+`, `-`, `*`, `/`, `%` and `**` are disabled by default. Enable them by passing `arithmetic_operators: true` to a new [`Liquid2::Environment`](https://github.com/jg-rp/ruby-liquid2/blob/main/lib/liquid2/environment.rb).
+Arithmetic infix operators `+`, `-`, `*`, `/`, `%` and `**`, and prefix operators `+` and `-`, are disabled by default. Enable them by passing `arithmetic_operators: true` to a new [`Liquid2::Environment`](https://github.com/jg-rp/ruby-liquid2/blob/main/lib/liquid2/environment.rb).
 
 #### Scientific notation
 

--- a/lib/liquid2/expressions/arithmetic.rb
+++ b/lib/liquid2/expressions/arithmetic.rb
@@ -89,12 +89,12 @@ module Liquid2 # :nodoc:
 
     def evaluate(context)
       right = context.evaluate(@right)
-      value = Liquid2::Filters.to_decimal(right, default: nil)
-      if value.respond_to?(:-@)
-        value.send(:-@)
-      else
-        context.env.undefined("-(#{Liquid2.to_output_string(right.inspect)})", node: self)
-      end
+      value = Liquid2::Filters.to_decimal(right,
+                                          default: nil) || context.env.undefined(
+                                            "-(#{Liquid2.to_output_string(right.inspect)})",
+                                            node: self
+                                          )
+      value.send(:-@)
     end
 
     def children = [@right]
@@ -110,12 +110,12 @@ module Liquid2 # :nodoc:
 
     def evaluate(context)
       right = context.evaluate(@right)
-      value = Liquid2::Filters.to_decimal(right, default: nil)
-      if value.respond_to?(:+@)
-        value.send(:+@)
-      else
-        context.env.undefined("+(#{Liquid2.to_output_string(right.inspect)})", node: self)
-      end
+      value = Liquid2::Filters.to_decimal(right,
+                                          default: nil) || context.env.undefined(
+                                            "+(#{Liquid2.to_output_string(right.inspect)})",
+                                            node: self
+                                          )
+      value.send(:+@)
     end
 
     def children = [@right]

--- a/lib/liquid2/expressions/arithmetic.rb
+++ b/lib/liquid2/expressions/arithmetic.rb
@@ -91,7 +91,7 @@ module Liquid2 # :nodoc:
       right = context.evaluate(@right)
       value = Liquid2::Filters.to_decimal(right,
                                           default: nil) || context.env.undefined(
-                                            "-(#{Liquid2.to_output_string(right.inspect)})",
+                                            "-(#{Liquid2.to_output_string(right)})",
                                             node: self
                                           )
       value.send(:-@)
@@ -112,7 +112,7 @@ module Liquid2 # :nodoc:
       right = context.evaluate(@right)
       value = Liquid2::Filters.to_decimal(right,
                                           default: nil) || context.env.undefined(
-                                            "+(#{Liquid2.to_output_string(right.inspect)})",
+                                            "+(#{Liquid2.to_output_string(right)})",
                                             node: self
                                           )
       value.send(:+@)

--- a/lib/liquid2/expressions/arithmetic.rb
+++ b/lib/liquid2/expressions/arithmetic.rb
@@ -78,4 +78,46 @@ module Liquid2 # :nodoc:
       left**right
     end
   end
+
+  # Prefix negation
+  class Negative < Expression
+    # @param right [Expression]
+    def initialize(token, right)
+      super(token)
+      @right = right
+    end
+
+    def evaluate(context)
+      right = context.evaluate(@right)
+      value = Liquid2::Filters.to_decimal(right, default: nil)
+      if value.respond_to?(:-@)
+        value.send(:-@)
+      else
+        context.env.undefined("-(#{Liquid2.to_output_string(right.inspect)})", node: self)
+      end
+    end
+
+    def children = [@right]
+  end
+
+  # Prefix positive
+  class Positive < Expression
+    # @param right [Expression]
+    def initialize(token, right)
+      super(token)
+      @right = right
+    end
+
+    def evaluate(context)
+      right = context.evaluate(@right)
+      value = Liquid2::Filters.to_decimal(right, default: nil)
+      if value.respond_to?(:+@)
+        value.send(:+@)
+      else
+        context.env.undefined("+(#{Liquid2.to_output_string(right.inspect)})", node: self)
+      end
+    end
+
+    def children = [@right]
+  end
 end

--- a/lib/liquid2/nodes/tags/raw.rb
+++ b/lib/liquid2/nodes/tags/raw.rb
@@ -10,7 +10,8 @@ module Liquid2
     def self.parse(token, parser)
       parser.carry_whitespace_control
       parser.eat(:token_tag_end)
-      # TODO: apply whitespace control to raw text
+      # TODO: apply whitespace control to raw text?
+      # Shopify/liquid does not apply whitespace control to raw content.
       raw = parser.eat(:token_raw)
       parser.eat_empty_tag("endraw")
       new(token, raw[1] || raise)

--- a/lib/liquid2/parser.rb
+++ b/lib/liquid2/parser.rb
@@ -829,7 +829,7 @@ module Liquid2
       case current_kind
       when :token_not
         token = self.next
-        expr = parse_primary
+        expr = parse_primary(precedence: Precedence::PREFIX)
         LogicalNot.new(token, expr)
       when :token_plus
         token = self.next
@@ -838,7 +838,7 @@ module Liquid2
                                       token)
         end
 
-        Positive.new(token, parse_primary)
+        Positive.new(token, parse_primary(precedence: Precedence::PREFIX))
       when :token_minus
         token = self.next
         unless @env.arithmetic_operators
@@ -846,7 +846,7 @@ module Liquid2
                                       token)
         end
 
-        Negative.new(token, parse_primary)
+        Negative.new(token, parse_primary(precedence: Precedence::PREFIX))
       else
         raise LiquidSyntaxError.new("unexpected prefix operator #{current[1]}", current)
       end

--- a/lib/liquid2/undefined.rb
+++ b/lib/liquid2/undefined.rb
@@ -28,8 +28,8 @@ module Liquid2
     def to_s = ""
     def to_i = 0
     def to_f = 0.0
-    def -@ = 0
-    def +@ = 0
+    def -@ = self
+    def +@ = self
     def each(...) = Enumerator.new {} # rubocop:disable Lint/EmptyBlock
     def each_with_index(...) = Enumerator.new {} # rubocop:disable Lint/EmptyBlock
     def join(...) = ""

--- a/lib/liquid2/undefined.rb
+++ b/lib/liquid2/undefined.rb
@@ -105,11 +105,11 @@ module Liquid2
     end
 
     def +@
-      raise UndefinedError.new(@message, @node.token)
+      self
     end
 
     def -@
-      raise UndefinedError.new(@message, @node.token)
+      self
     end
 
     def each(...)
@@ -125,7 +125,7 @@ module Liquid2
     end
 
     def to_liquid(_context)
-      raise UndefinedError.new(@message, @node.token)
+      self
     end
 
     def poke

--- a/lib/liquid2/undefined.rb
+++ b/lib/liquid2/undefined.rb
@@ -28,6 +28,8 @@ module Liquid2
     def to_s = ""
     def to_i = 0
     def to_f = 0.0
+    def -@ = 0
+    def +@ = 0
     def each(...) = Enumerator.new {} # rubocop:disable Lint/EmptyBlock
     def each_with_index(...) = Enumerator.new {} # rubocop:disable Lint/EmptyBlock
     def join(...) = ""
@@ -99,6 +101,14 @@ module Liquid2
     end
 
     def to_f
+      raise UndefinedError.new(@message, @node.token)
+    end
+
+    def +@
+      raise UndefinedError.new(@message, @node.token)
+    end
+
+    def -@
       raise UndefinedError.new(@message, @node.token)
     end
 

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -640,6 +640,10 @@ module Liquid2
     def to_s: () -> ""
 
     def to_i: () -> 0
+            
+    def +@: () -> 0
+          
+    def -@: () -> 0
 
     def to_f: () -> ::Float
 
@@ -689,6 +693,10 @@ module Liquid2
     def to_s: () -> untyped
 
     def to_i: () -> untyped
+            
+    def +@: () -> untyped
+          
+    def -@: () -> untyped
 
     def to_f: () -> untyped
 

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -1603,7 +1603,7 @@ module Liquid2
     def self.to_integer: (untyped obj) -> Integer
 
     # Cast _obj_ to a number, favouring BigDecimal over Float.
-    def self.to_decimal: (untyped obj, ?default: ::Integer) -> (Integer | BigDecimal | Numeric)
+    def self.to_decimal: (untyped obj, ?default: untyped) -> (Integer | BigDecimal | Numeric)
 
     # Cast _obj_ to a  date and time. Return `nil` if casting fails.
     def self.to_date: (untyped obj) -> untyped
@@ -2606,6 +2606,26 @@ module Liquid2
 
   # Infix exponentiation
   class Pow < ArithmeticExpression
+    def evaluate: (RenderContext context) -> untyped
+  end
+
+  # Prefix negation
+  class Negative < Expression
+    @right: untyped
+
+    # @param right [Expression]
+    def initialize: ([Symbol, String?, Integer] token, untyped right) -> void
+
+    def evaluate: (RenderContext context) -> untyped
+  end
+
+  # Prefix positive
+  class Positive < Expression
+    @right: untyped
+
+    # @param right [Expression]
+    def initialize: ([Symbol, String?, Integer] token, untyped right) -> void
+
     def evaluate: (RenderContext context) -> untyped
   end
 end

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -619,33 +619,33 @@ module Liquid2
 
     def []: (*untyped) ?{ (?) -> untyped } -> self
 
-    def key?: (*untyped) ?{ (?) -> untyped } -> false
+    def key?: (*untyped) ?{ (?) -> untyped } -> untyped
 
-    def include?: (*untyped) ?{ (?) -> untyped } -> false
+    def include?: (*untyped) ?{ (?) -> untyped } -> untyped
 
-    def member?: (*untyped) ?{ (?) -> untyped } -> false
+    def member?: (*untyped) ?{ (?) -> untyped } -> untyped
 
     def fetch: (*untyped) ?{ (?) -> untyped } -> self
 
-    def !: () -> true
+    def !: () -> untyped
 
     def ==: (untyped other) -> untyped
 
     alias eql? ==
 
-    def size: () -> 0
+    def size: () -> untyped
 
-    def length: () -> 0
+    def length: () -> untyped
 
     def to_s: () -> ""
 
-    def to_i: () -> 0
+    def to_i: () -> untyped
             
-    def +@: () -> 0
+    def +@: () -> untyped
           
-    def -@: () -> 0
+    def -@: () -> untyped
 
-    def to_f: () -> ::Float
+    def to_f: () -> untyped
 
     def each: (*untyped) ?{ (?) -> untyped } -> untyped
 
@@ -653,9 +653,9 @@ module Liquid2
                        
     def join: (*untyped) -> ""
 
-    def to_liquid: (RenderContext _context) -> nil
+    def to_liquid: (RenderContext _context) -> untyped
 
-    def poke: () -> true
+    def poke: () -> bool
   end
 
   # An undefined type that always raises an exception.

--- a/test/arithmetic.json
+++ b/test/arithmetic.json
@@ -269,6 +269,27 @@
       "name": "group terms to times is evaluated before pow",
       "template": "{{ (2 * 2)**3 }}",
       "result": "64"
+    },
+    {
+      "name": "negate",
+      "template": "{{ -(1+2) }}",
+      "result": "-3"
+    },
+    {
+      "name": "unary minus takes priority over infix plus",
+      "template": "{{ -1+2 }}",
+      "result": "1"
+    },
+    {
+      "name": "unary plus, int as string",
+      "template": "{{ +a - 3 }}",
+      "data": { "a": 42 },
+      "result": "39"
+    },
+    {
+      "name": "unary plus, undefined",
+      "template": "{{ +a - 3 }}",
+      "result": "-3"
     }
   ]
 }

--- a/test/compound.json
+++ b/test/compound.json
@@ -1,0 +1,64 @@
+{
+  "tests": [
+    {
+      "name": "logical and, last value, truthy left",
+      "template": "{{ true and 42 }}",
+      "result": "42"
+    },
+    {
+      "name": "logical and, last value, falsy left",
+      "template": "{{ false and 42 }}",
+      "result": "false"
+    },
+    {
+      "name": "logical or, last value, truthy left",
+      "template": "{{ 99 or 42 }}",
+      "result": "99"
+    },
+    {
+      "name": "logical or, last value, falsy left",
+      "template": "{{ false or 42 }}",
+      "result": "42"
+    },
+    {
+      "name": "logical and, falsy left, or truthy",
+      "template": "{{ false and 42 or 99 }}",
+      "result": "99"
+    },
+    {
+      "name": "arithmetic and relational, truthy",
+      "template": "{{ 1 + 2 <= 3 }}",
+      "result": "true"
+    },
+    {
+      "name": "arithmetic and relational, falsy",
+      "template": "{{ 1 + 2 > 3 }}",
+      "result": "false"
+    },
+    {
+      "name": "if tag, arithmetic and relational",
+      "template": "{% if 1 + 2 <= 3 %}true{% endif %}",
+      "result": "true"
+    },
+    {
+      "name": "arithmetic, relational and logical, truthy",
+      "template": "{{ 1 + 2 > 3 or 4 < 5 }}",
+      "result": "true"
+    },
+    {
+      "name": "arithmetic, plus false",
+      "template": "{{ 1 + (2 > 3) }}",
+      "result": "1"
+    },
+    {
+      "name": "arithmetic, plus true",
+      "template": "{{ 1 + (2 < 3) }}",
+      "result": "1"
+    },
+    {
+      "name": "arithmetic operators bind more tightly than relational operators",
+      "template": "{{ 1 + 2 == 3 }}",
+      "result": "true"
+    }
+  ]
+}

--- a/test/compound.json
+++ b/test/compound.json
@@ -59,6 +59,11 @@
       "name": "arithmetic operators bind more tightly than relational operators",
       "template": "{{ 1 + 2 == 3 }}",
       "result": "true"
+    },
+    {
+      "name": "not binds more tightly than or",
+      "template": "{{ not false or true  }}",
+      "result": "true"
     }
   ]
 }

--- a/test/test_compound_expressions.rb
+++ b/test/test_compound_expressions.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "json"
+require "test_helper"
+
+class TestCompoundExpressions < Minitest::Spec
+  make_my_diffs_pretty!
+
+  TEST_CASES = JSON.load_file("test/compound.json")
+
+  describe "compound expressions" do
+    TEST_CASES["tests"].each do |test_case|
+      it test_case["name"] do
+        loader = if (templates = test_case["templates"])
+                   Liquid2::HashLoader.new(templates)
+                 end
+
+        env = Liquid2::Environment.new(loader: loader, arithmetic_operators: true)
+        if test_case["invalid"]
+          assert_raises Liquid2::LiquidError do
+            env.parse(test_case["template"]).render(test_case["data"])
+          end
+        else
+          template = env.parse(test_case["template"])
+          if test_case["result"]
+            _(template.render(test_case["data"])).must_equal test_case["result"]
+          else
+            _(test_case["results"]).must_include template.render(test_case["data"])
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/test_syntax_errors.rb
+++ b/test/test_syntax_errors.rb
@@ -104,14 +104,14 @@ class TestLiquidSyntaxErrors < Minitest::Test
 
   def test_hyphen_string
     source = "{{ -'foo' }}"
-    message = "unexpected token_minus"
+    message = "unexpected prefix operator -"
     error = assert_raises(Liquid2::LiquidSyntaxError) { Liquid2.render(source) }
     assert_equal(message, error.message)
   end
 
   def test_unknown_prefix_operator
     source = "{{ +5 }}"
-    message = "unexpected token_plus"
+    message = "unexpected prefix operator +"
     error = assert_raises(Liquid2::LiquidSyntaxError) { Liquid2.render(source) }
     assert_equal(message, error.message)
   end

--- a/test/test_undefined.rb
+++ b/test/test_undefined.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestUndefinedCVariables < Minitest::Test
+  def test_falsy_strict_undefined
+    source = "{% if nosuchthing %}foo{% else %}bar{% endif %}"
+    env = Liquid2::Environment.new(falsy_undefined: true, undefined: Liquid2::StrictUndefined)
+
+    assert_equal("bar", env.render(source))
+  end
+
+  def test_disable_falsy_strict_undefined
+    source = "{% if nosuchthing %}foo{% else %}bar{% endif %}"
+    env = Liquid2::Environment.new(falsy_undefined: false, undefined: Liquid2::StrictUndefined)
+
+    message = "nosuchthing is undefined"
+    error = assert_raises(Liquid2::UndefinedError) { env.render(source) }
+    assert_equal(message, error.message)
+  end
+
+  def test_inline_falsy_strict_undefined
+    source = "{{ nosuchthing or \"bar\" }}"
+    env = Liquid2::Environment.new(falsy_undefined: true, undefined: Liquid2::StrictUndefined)
+
+    assert_equal("bar", env.render(source))
+  end
+
+  def test_disable_inline_falsy_strict_undefined
+    source = "{{ nosuchthing or \"bar\" }}"
+    env = Liquid2::Environment.new(falsy_undefined: false, undefined: Liquid2::StrictUndefined)
+
+    message = "nosuchthing is undefined"
+    error = assert_raises(Liquid2::UndefinedError) { env.render(source) }
+    assert_equal(message, error.message)
+  end
+
+  def test_ternary_falsy_strict_undefined
+    source = "{{ \"foo\" if nosuchthing else \"bar\" }}"
+    env = Liquid2::Environment.new(falsy_undefined: true, undefined: Liquid2::StrictUndefined)
+
+    assert_equal("bar", env.render(source))
+  end
+
+  def test_disable_ternary_falsy_strict_undefined
+    source = "{{ \"foo\" if nosuchthing else \"bar\" }}"
+    env = Liquid2::Environment.new(falsy_undefined: false, undefined: Liquid2::StrictUndefined)
+
+    message = "nosuchthing is undefined"
+    error = assert_raises(Liquid2::UndefinedError) { env.render(source) }
+    assert_equal(message, error.message)
+  end
+
+  def test_prefix_coerced_to_undefined
+    source = "{{ -'foo' or 'bar' }}"
+    env = Liquid2::Environment.new(falsy_undefined: true,
+                                   undefined: Liquid2::StrictUndefined,
+                                   arithmetic_operators: true)
+
+    assert_equal("bar", env.render(source))
+  end
+
+  def test_disable_falsy_prefix_coerced_to_undefined
+    source = "{{ -'foo' or 'bar' }}"
+    env = Liquid2::Environment.new(falsy_undefined: false,
+                                   undefined: Liquid2::StrictUndefined,
+                                   arithmetic_operators: true)
+
+    message = "\"-(foo)\" is undefined"
+    error = assert_raises(Liquid2::UndefinedError) { env.render(source) }
+    assert_equal(message, error.message)
+  end
+end

--- a/test/test_undefined.rb
+++ b/test/test_undefined.rb
@@ -54,6 +54,14 @@ class TestUndefinedCVariables < Minitest::Test
   def test_prefix_coerced_to_undefined
     source = "{{ -'foo' or 'bar' }}"
     env = Liquid2::Environment.new(falsy_undefined: true,
+                                   arithmetic_operators: true)
+
+    assert_equal("bar", env.render(source))
+  end
+
+  def test_prefix_coerced_to_strict_undefined
+    source = "{{ -'foo' or 'bar' }}"
+    env = Liquid2::Environment.new(falsy_undefined: true,
                                    undefined: Liquid2::StrictUndefined,
                                    arithmetic_operators: true)
 


### PR DESCRIPTION
Add support for unary `+` and `-` operators.

```ruby
require "liquid2"

env = Liquid2::Environment.new(arithmetic_operators: true)

source = <<~LIQUID.chomp
  {{ -(1+2) }}
  {{ -1+2 }}
  {{ -"42" }}
  {{ +"42" }}
LIQUID

puts env.render(source)
```

```
-3
1
-42
42
```

If the operand can't be coerced to a number following the same semantics as math filters, an instance of `Liquid::Undefined` is used instead.