### PR TITLE
Fix parse variable path starting with `true`, `false`, `nil` or `null`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [unreleased]
 
+- Fixed parsing of variable paths that start with `true`, `false`, `nil` or `null`. For example, `{{ true.foo }}`. See [#13](https://github.com/jg-rp/ruby-liquid2/issues/13).
 - Added support for arithmetic infix operators `+`, `-`, `*`, `/`, `%` and `**`, and prefix operators `+` and `-`. These operators are disabled by default. Enable them by passing `arithmetic_operators: true` to a new `Liquid2::Environment`.
 
 ## [0.2.0] - 25-05-12

--- a/lib/liquid2/expressions/lambda.rb
+++ b/lib/liquid2/expressions/lambda.rb
@@ -19,6 +19,8 @@ module Liquid2
 
     def children = [@expr]
 
+    # TODO: scope
+
     # Apply this lambda function to elements from _enum_.
     # @param context [RenderContext]
     # @param enum [Enumerable<Object>]

--- a/lib/liquid2/parser.rb
+++ b/lib/liquid2/parser.rb
@@ -337,14 +337,26 @@ module Liquid2
 
       left = case kind
              when :token_true
-               self.next
-               looks_like_a_path ? parse_path : true
+               if looks_like_a_path
+                 parse_path
+               else
+                 self.next
+                 true
+               end
              when :token_false
-               self.next
-               looks_like_a_path ? parse_path : false
+               if looks_like_a_path
+                 parse_path
+               else
+                 self.next
+                 false
+               end
              when :token_nil
-               self.next
-               looks_like_a_path ? parse_path : nil
+               if looks_like_a_path
+                 parse_path
+               else
+                 self.next
+                 nil
+               end
              when :token_int
                Liquid2.to_liquid_int(self.next[1])
              when :token_float
@@ -536,10 +548,10 @@ module Liquid2
       LOGICAL_AND = 4
       RELATIONAL = 5
       MEMBERSHIP = 6
-      PREFIX = 7
       ADD_SUB = 8
       MUL_DIV = 9
       POW = 10
+      PREFIX = 11
     end
 
     PRECEDENCES = {

--- a/test/compound.json
+++ b/test/compound.json
@@ -64,6 +64,32 @@
       "name": "not binds more tightly than or",
       "template": "{{ not false or true  }}",
       "result": "true"
+    },
+    {
+      "name": "filter arguments",
+      "template": "{{ a | split: b or ',' | join: c or '#'  }}",
+      "data": {
+        "a": "1,2,3,4",
+        "b": null,
+        "c": "*"
+      },
+      "result": "1*2*3*4"
+    },
+    {
+      "name": "loop target",
+      "template": "{% for x in y or a %}{{ x + 2 }}, {% endfor %}",
+      "data": {
+        "a": [1, 2, 3]
+      },
+      "result": "3, 4, 5, "
+    },
+    {
+      "name": "lambda expression",
+      "template": "{{ x or a | map: i => i + 2 | join: ', ' }}",
+      "data": {
+        "a": [1, 2, 3]
+      },
+      "result": "3, 4, 5"
     }
   ]
 }

--- a/test/test_issues.rb
+++ b/test/test_issues.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestIssues < Minitest::Test
+  def test_issue13
+    source = "{{ true.foo }} {{ false.foo }} {{ nil.foo }} {{ null.foo }} {{ and.foo }}"
+    data = { "true" => { "foo" => 42 },
+             "false" => { "foo" => 43 },
+             "nil" => { "foo" => 44 },
+             "null" => { "foo" => 45 },
+             "and" => { "foo" => 46 } }
+
+    assert_equal("42 43 44 45 46", Liquid2.render(source, data))
+  end
+end


### PR DESCRIPTION
Closes #13.