### PR TITLE
Include a better `slice` filter

### DIFF
--- a/lib/liquid2/filters/slice.rb
+++ b/lib/liquid2/filters/slice.rb
@@ -13,5 +13,45 @@ module Liquid2
         Liquid2.to_s(left).slice(to_integer(start), to_integer(length)) || ""
       end
     end
+
+    def self.better_slice(
+      left,
+      start_ = :undefined, stop_ = :undefined, step_ = :undefined,
+      start: :undefined, stop: :undefined, step: :undefined
+    )
+      # Give priority to keyword arguments, default to nil if neither are given.
+      start = start_ == :undefined ? nil : start_ if start == :undefined
+      stop = stop_ == :undefined ? nil : stop_ if stop == :undefined
+      step = step_ == :undefined ? nil : step_ if step == :undefined
+
+      step = Integer(step || 1)
+      length = left.length
+      return [] if length.zero? || step.zero?
+
+      start = Integer(start) unless start.nil?
+      stop = Integer(stop) unless stop.nil?
+
+      normalized_start = if start.nil?
+                           step.negative? ? length - 1 : 0
+                         elsif start&.negative?
+                           [length + start, 0].max
+                         else
+                           [start, length - 1].min
+                         end
+
+      normalized_stop = if stop.nil?
+                          step.negative? ? -1 : length
+                        elsif stop&.negative?
+                          [length + stop, -1].max
+                        else
+                          [stop, length].min
+                        end
+
+      # This does not work with Ruby 3.1
+      # left[(normalized_start...normalized_stop).step(step)]
+      #
+      # But this does.
+      (normalized_start...normalized_stop).step(step).map { |i| left[i] }
+    end
   end
 end

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -1894,6 +1894,8 @@ module Liquid2
     
     # Return the subsequence of _left_ starting at _start_ up to _length_.
     def self.slice: (untyped left, untyped start, ?untyped length) -> untyped
+                  
+    def self.better_slice: (untyped left, ?untyped start_, ?untyped stop_, ?untyped step_, ?start: untyped, ?stop: untyped, ?step: untyped) -> untyped
 
     # Return _left_ with all characters converted to uppercase.
     # Coerce _left_ to a string if it is not one already.


### PR DESCRIPTION
Include a better `slice` filter, defined in `Liquid2::Filters.better_slice`.

The new filter accepts optional start, stop and step arguments, all of which can be negative and can be given as positional or keyword arguments.  This is in contrast to the standard `slice` filter that accepts a start index and optional length, neither of which can be negative.

I want registered this filter in `Liquid2::DEFAULT_ENVIRONMENT`, but I don't want to replace the default `slice` filter. At the moment I'm thinking `range` is the best name to use so as not to conflict with `slice`.

```liquid
{{ some_array | range: 2, 8, 2 }}
{{ some_array | range: start:2, stop:8,  step:2 }}
```