### PR TITLE
Add env option for configuring persistent namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.4.0] - unreleased
+
+- Added `Liquid2::Environment.persistent_namespaces`. It is an array of symbols indicating which namespaces from `Liquid2::RenderContext.tag_namespaces` should be preserved when calling `Liquid2::RenderContext#copy`. This is important for some tags - like `{% extends %}` - that need to share state with partial templates rendered with `{% render %}`.
+
 ## [0.3.1] - 25-06-24
 
 - Added support for custom markup delimiters. See [#16](https://github.com/jg-rp/ruby-liquid2/pull/16).

--- a/lib/liquid2/context.rb
+++ b/lib/liquid2/context.rb
@@ -219,8 +219,10 @@ module Liquid2
                                loop_carry: loop_carry,
                                local_namespace_carry: @assign_score)
 
-      # XXX: bit of a hack
-      context.tag_namespace[:extends] = @tag_namespace[:extends]
+      @env.persistent_namespaces.each do |ns|
+        context.tag_namespace[ns] = @tag_namespace[ns] if @tag_namespace[ns]
+      end
+
       context
     end
 

--- a/lib/liquid2/environment.rb
+++ b/lib/liquid2/environment.rb
@@ -51,7 +51,7 @@ module Liquid2
                 :re_double_quote_string_special, :re_single_quote_string_special, :re_markup_start,
                 :re_markup_end, :re_markup_end_chars, :re_up_to_markup_start, :re_punctuation,
                 :re_up_to_inline_comment_end, :re_up_to_raw_end, :re_block_comment_chunk,
-                :re_up_to_doc_end, :re_line_statement_comment
+                :re_up_to_doc_end, :re_line_statement_comment, :persistent_namespaces
 
     # @param context_depth_limit [Integer] The maximum number of times a render context can
     #   be extended or copied before a `Liquid2::LiquidResourceLimitError`` is raised.
@@ -116,6 +116,10 @@ module Liquid2
       # along with a flag to indicate if the callable accepts a `context`
       # keyword argument.
       @filters = {}
+
+      # An array of symbols indicating which namespaces from RenderContext.tag_namespaces
+      # should be preserved when using RenderContext#copy.
+      @persistent_namespaces = [:extends]
 
       # When `true`, arithmetic operators `+`, `-`, `*`, `/`, `%` and `**` are enabled.
       # Defaults to `false`.

--- a/lib/liquid2/version.rb
+++ b/lib/liquid2/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Liquid2
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -62,6 +62,8 @@ module Liquid2
     # keyword argument.
     @filters: Hash[String, [_Filter, (Integer | nil)]]
 
+    @persistent_namespaces: Array[Symbol]
+
     @local_namespace_limit: Integer?
 
     @context_depth_limit: Integer
@@ -153,6 +155,8 @@ module Liquid2
     @re_line_statement_comment: Regexp
 
     attr_reader tags: Hash[String, _Tag]
+
+    attr_reader persistent_namespaces: Array[Symbol]
 
     attr_reader local_namespace_limit: Integer?
 


### PR DESCRIPTION
Add `Liquid2::Environment.persistent_namespaces`. It is an array of symbols indicating which namespaces from `Liquid2::RenderContext.tag_namespaces` should be preserved when calling `Liquid2::RenderContext#copy`.

This is important for some tags - like `{% extends %}` - that need to share state with partial templates rendered with `{% render %}`.

Closes #24 