### PR TITLE
Add automatic whitespace trimming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [0.4.0] - unreleased
 
 - Added `Liquid2::Environment.persistent_namespaces`. It is an array of symbols indicating which namespaces from `Liquid2::RenderContext.tag_namespaces` should be preserved when calling `Liquid2::RenderContext#copy`. This is important for some tags - like `{% extends %}` - that need to share state with partial templates rendered with `{% render %}`.
+- Added the `auto_trim` argument to `Liquid2::Environment`. `auto_trim` can be `'-'`, `'~'` or `nil` (the default). When not `nil`, it sets the automatic whitespace trimming applied to the left side of template text when no explicit whitespace control is given. `+` is also available as whitespace control in tags, outputs statements and comments. A `+` will ensure no trimming is applied, even if `auto_trim` is set.
 
 ## [0.3.1] - 25-06-24
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    liquid2 (0.3.1)
+    liquid2 (0.4.0)
       base64 (~> 0.2)
       bigdecimal (~> 3.1)
 

--- a/lib/liquid2/environment.rb
+++ b/lib/liquid2/environment.rb
@@ -53,6 +53,11 @@ module Liquid2
                 :re_up_to_inline_comment_end, :re_up_to_raw_end, :re_block_comment_chunk,
                 :re_up_to_doc_end, :re_line_statement_comment, :persistent_namespaces
 
+    # @param arithmetic_operators [bool] When `true`, arithmetic operators `+`, `-`, `*`, `/`, `%`
+    #   and `**` are enabled.
+    # @auto_trim ['-' | '~' | nil] Whitespace trimming to apply to the left of text when
+    #   neither `-` or `~` is given for any tag, output statement or comment. The default is
+    #   `nil`, which means no automatic whitespace trimming is applied.
     # @param context_depth_limit [Integer] The maximum number of times a render context can
     #   be extended or copied before a `Liquid2::LiquidResourceLimitError`` is raised.
     # @param globals [Hash[String, untyped]?] Variables that are available to all templates
@@ -91,6 +96,7 @@ module Liquid2
     def initialize(
       arithmetic_operators: false,
       context_depth_limit: 30,
+      auto_trim: nil,
       falsy_undefined: true,
       globals: nil,
       loader: nil,
@@ -128,6 +134,11 @@ module Liquid2
       # The maximum number of times a render context can be extended or copied before
       # a Liquid2::LiquidResourceLimitError is raised.
       @context_depth_limit = context_depth_limit
+
+      # The default whitespace trimming applied to the left of text content when neither
+      # `-` or `~` is specified. Defaults to `nil`, which means no automatic whitespace
+      # trimming.
+      @auto_trim = auto_trim
 
       # Variables that are available to all templates rendered from this environment.
       @globals = globals
@@ -412,7 +423,7 @@ module Liquid2
 
     # Trim _text_.
     def trim(text, left_trim, right_trim)
-      case left_trim
+      case left_trim || @auto_trim
       when "-"
         text.lstrip!
       when "~"

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -92,6 +92,8 @@ module Liquid2
 
     @arithmetic_operators: bool
 
+    @auto_trim: '-' | '~' | nil
+
     # The string of characters that indicate the start of a Liquid output statement.
     @markup_out_start: String
 
@@ -220,7 +222,7 @@ module Liquid2
 
     attr_reader re_line_statement_comment: Regexp
 
-    def initialize: (?arithmetic_operators: bool, ?context_depth_limit: ::Integer, ?falsy_undefined: bool, ?globals: untyped?, ?loader: TemplateLoader?, ?local_namespace_limit: Integer?, ?loop_iteration_limit: Integer?, ?markup_comment_prefix: ::String, ?markup_comment_suffix: ::String, ?markup_out_end: ::String, ?markup_out_start: ::String, ?markup_tag_end: ::String, ?markup_tag_start: ::String, ?output_stream_limit: Integer?, ?parser: singleton(Parser), ?scanner: singleton(Scanner), ?shorthand_indexes: bool, ?suppress_blank_control_flow_blocks: bool, ?undefined: singleton(Undefined)) -> void
+    def initialize: (?arithmetic_operators: bool, ?context_depth_limit: ::Integer, ?auto_trim: '-' | '~' | nil, ?falsy_undefined: bool, ?globals: untyped?, ?loader: TemplateLoader?, ?local_namespace_limit: Integer?, ?loop_iteration_limit: Integer?, ?markup_comment_prefix: ::String, ?markup_comment_suffix: ::String, ?markup_out_end: ::String, ?markup_out_start: ::String, ?markup_tag_end: ::String, ?markup_tag_start: ::String, ?output_stream_limit: Integer?, ?parser: singleton(Parser), ?scanner: singleton(Scanner), ?shorthand_indexes: bool, ?suppress_blank_control_flow_blocks: bool, ?undefined: singleton(Undefined)) -> void
 
     # @param source [String] template source text.
     # @return [Template]

--- a/test/test_whitespace_control.rb
+++ b/test/test_whitespace_control.rb
@@ -3,6 +3,27 @@
 require "test_helper"
 
 class TestWhitespaceControl < Minitest::Test
+  def test_no_whitespace_control
+    source = <<~LIQUID
+      <ul>
+      {% for x in (1..4) %}
+        <li>{{ x }}</li>
+      {% endfor %}
+      </ul>
+    LIQUID
+
+    expect = <<~LIQUID
+      <ul>\n
+        <li>1</li>\n
+        <li>2</li>\n
+        <li>3</li>\n
+        <li>4</li>\n
+      </ul>
+    LIQUID
+
+    assert_equal(expect, Liquid2.render(source))
+  end
+
   def test_tilde
     source = <<~LIQUID
       <ul>
@@ -22,5 +43,97 @@ class TestWhitespaceControl < Minitest::Test
     LIQUID
 
     assert_equal(expect, Liquid2.render(source))
+  end
+
+  def test_auto_trim_tilde
+    source = <<~LIQUID
+      <ul>
+      {% for x in (1..4) %}
+        <li>{{ x }}</li>
+      {% endfor %}
+      </ul>
+    LIQUID
+
+    expect = <<~LIQUID
+      <ul>
+        <li>1</li>
+        <li>2</li>
+        <li>3</li>
+        <li>4</li>
+      </ul>
+    LIQUID
+
+    env = Liquid2::Environment.new(auto_trim: "~")
+
+    assert_equal(expect, env.render(source))
+  end
+
+  def test_auto_trim_hyphen
+    source = <<~LIQUID
+      <ul>
+      {% for x in (1..4) %}
+        <li>{{ x }}</li>
+      {% endfor %}
+      </ul>
+    LIQUID
+
+    expect = <<~LIQUID
+      <ul>
+      <li>1</li>
+      <li>2</li>
+      <li>3</li>
+      <li>4</li>
+      </ul>
+    LIQUID
+
+    env = Liquid2::Environment.new(auto_trim: "-")
+
+    assert_equal(expect, env.render(source))
+  end
+
+  def test_override_auto_trim
+    source = <<~LIQUID
+      <ul>
+      {% for x in (1..4) ~%}
+        <li>{{ x }}</li>
+      {% endfor %}
+      </ul>
+    LIQUID
+
+    expect = <<~LIQUID
+      <ul>
+        <li>1</li>
+        <li>2</li>
+        <li>3</li>
+        <li>4</li>
+      </ul>
+    LIQUID
+
+    env = Liquid2::Environment.new(auto_trim: "-")
+
+    assert_equal(expect, env.render(source))
+  end
+
+  def test_override_auto_trim_with_plus
+    source = <<~LIQUID
+      <ul>
+      {% for x in (1..4) +%}
+        <li>{{ x }}</li>
+      {% endfor +%}
+      </ul>
+    LIQUID
+
+    expect = <<~LIQUID
+      <ul>\n
+        <li>1</li>\n
+        <li>2</li>\n
+        <li>3</li>\n
+        <li>4</li>\n
+      </ul>
+    LIQUID
+
+    env = Liquid2::Environment.new(auto_trim: "-")
+
+    assert_equal(expect, env.render(source))
   end
 end


### PR DESCRIPTION
Add an `auto_trim` argument to `Liquid2::Environment`. `auto_trim` can be `'-'`, `'~'` or `nil` (the default). When not `nil`, it sets the automatic whitespace trimming applied to the left side of template text when no explicit whitespace control is given.

 `+` is also available as whitespace control in tags, outputs statements and comments. A `+` will ensure no trimming is applied, even if `auto_trim` is set.

Closes #25 