### PR TITLE
Fix syntax error from identical markup end delimiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [0.4.0] - unreleased
 
+- Fixed a bug where the parser would raise a `Liquid2::LiquidSyntaxError` if environment arguments `markup_out_end` and `markup_tag_end` where identical. See [#23](https://github.com/jg-rp/ruby-liquid2/issues/23).
 - Added `Liquid2::Environment.persistent_namespaces`. It is an array of symbols indicating which namespaces from `Liquid2::RenderContext.tag_namespaces` should be preserved when calling `Liquid2::RenderContext#copy`. This is important for some tags - like `{% extends %}` - that need to share state with partial templates rendered with `{% render %}`.
 - Added the `auto_trim` argument to `Liquid2::Environment`. `auto_trim` can be `'-'`, `'~'` or `nil` (the default). When not `nil`, it sets the automatic whitespace trimming applied to the left side of template text when no explicit whitespace control is given. `+` is also available as whitespace control in tags, outputs statements and comments. A `+` will ensure no trimming is applied, even if `auto_trim` is set.
 

--- a/lib/liquid2/environment.rb
+++ b/lib/liquid2/environment.rb
@@ -51,7 +51,8 @@ module Liquid2
                 :re_double_quote_string_special, :re_single_quote_string_special, :re_markup_start,
                 :re_markup_end, :re_markup_end_chars, :re_up_to_markup_start, :re_punctuation,
                 :re_up_to_inline_comment_end, :re_up_to_raw_end, :re_block_comment_chunk,
-                :re_up_to_doc_end, :re_line_statement_comment, :persistent_namespaces
+                :re_up_to_doc_end, :re_line_statement_comment, :persistent_namespaces,
+                :universal_markup_end
 
     # @param arithmetic_operators [bool] When `true`, arithmetic operators `+`, `-`, `*`, `/`, `%`
     #   and `**` are enabled.
@@ -199,6 +200,10 @@ module Liquid2
 
       # The string of characters that indicate the end of a Liquid tag.
       @markup_tag_end = markup_tag_end
+
+      # Indicates if tag and output end delimiters are identical. This is used by the
+      # parser when parsing output statements.
+      @universal_markup_end = markup_tag_end == markup_out_end
 
       # The string of characters that indicate the start of a Liquid comment. This should
       # include a single trailing `#`. Additional, variable length hashes will be handled

--- a/lib/liquid2/parser.rb
+++ b/lib/liquid2/parser.rb
@@ -43,6 +43,10 @@ module Liquid2
       @pos = 0
       @eof = [:token_eof, nil, length - 1]
       @whitespace_carry = nil
+
+      # If both tags and output statements share the same end delimiter, we expect
+      # `:token_tag_end` to close an output statement as the scanner scans for tags first.
+      @output_end = @env.universal_markup_end ? :token_tag_end : :token_output_end
     end
 
     # Return the current token without advancing the pointer.
@@ -691,7 +695,7 @@ module Liquid2
     def parse_output
       expr = parse_filtered_expression
       carry_whitespace_control
-      eat(:token_output_end)
+      eat(@output_end)
       Output.new(expr.token, expr)
     end
 

--- a/lib/liquid2/scanner.rb
+++ b/lib/liquid2/scanner.rb
@@ -240,10 +240,10 @@ module Liquid2
 
       # Miro benchmarks show no performance gain using scan_byte and peek_byte over scan here.
       case @scanner.scan(@re_markup_end)
-      when @s_out_end
-        @tokens << [:token_output_end, nil, @start]
       when @s_tag_end
         @tokens << [:token_tag_end, nil, @start]
+      when @s_out_end
+        @tokens << [:token_output_end, nil, @start]
       else
         # Unexpected token
         return nil if @scanner.eos?
@@ -306,10 +306,10 @@ module Liquid2
       accept_whitespace_control
 
       case @scanner.scan(@re_markup_end)
-      when @s_out_end
-        @tokens << [:token_output_end, nil, @start]
       when @s_tag_end
         @tokens << [:token_tag_end, nil, @start]
+      when @s_out_end
+        @tokens << [:token_output_end, nil, @start]
       else
         # Unexpected token
         return nil if @scanner.eos?
@@ -326,11 +326,11 @@ module Liquid2
       accept_whitespace_control
 
       case @scanner.scan(@re_markup_end)
-      when @s_out_end
-        @tokens << [:token_output_end, nil, @start]
-        @start = @scanner.pos
       when @s_tag_end
         @tokens << [:token_tag_end, nil, @start]
+        @start = @scanner.pos
+      when @s_out_end
+        @tokens << [:token_output_end, nil, @start]
         @start = @scanner.pos
       end
 
@@ -347,11 +347,11 @@ module Liquid2
       accept_whitespace_control
 
       case @scanner.scan(@re_markup_end)
-      when @s_out_end
-        @tokens << [:token_output_end, nil, @start]
-        @start = @scanner.pos
       when @s_tag_end
         @tokens << [:token_tag_end, nil, @start]
+        @start = @scanner.pos
+      when @s_out_end
+        @tokens << [:token_output_end, nil, @start]
         @start = @scanner.pos
       end
 
@@ -393,11 +393,11 @@ module Liquid2
       accept_whitespace_control
 
       case @scanner.scan(@re_markup_end)
-      when @s_out_end
-        @tokens << [:token_output_end, nil, @start]
-        @start = @scanner.pos
       when @s_tag_end
         @tokens << [:token_tag_end, nil, @start]
+        @start = @scanner.pos
+      when @s_out_end
+        @tokens << [:token_output_end, nil, @start]
         @start = @scanner.pos
       end
 
@@ -434,11 +434,11 @@ module Liquid2
       else
         accept_whitespace_control
         case @scanner.scan(@re_markup_end)
-        when @s_out_end
-          @tokens << [:token_output_end, nil, @start]
-          @start = @scanner.pos
         when @s_tag_end
           @tokens << [:token_tag_end, nil, @start]
+          @start = @scanner.pos
+        when @s_out_end
+          @tokens << [:token_output_end, nil, @start]
           @start = @scanner.pos
         end
 
@@ -485,11 +485,11 @@ module Liquid2
             @tokens << [:token_tag_end, nil, @start]
             accept_whitespace_control
             case @scanner.scan(@re_markup_end)
-            when @s_out_end
-              @tokens << [:token_output_end, nil, @start]
-              @start = @scanner.pos
             when @s_tag_end
               @tokens << [:token_tag_end, nil, @start]
+              @start = @scanner.pos
+            when @s_out_end
+              @tokens << [:token_output_end, nil, @start]
               @start = @scanner.pos
             end
 

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -106,6 +106,8 @@ module Liquid2
     # The string of characters that indicate the end of a Liquid tag.
     @markup_tag_end: String
 
+    @universal_markup_end: bool
+
     # The string of characters that indicate the start of a Liquid comment. This should
     # include a single trailing `#`. Additional, variable length hashes will be handled
     # by the tokenizer. It is not possible to change comment syntax to not use `#`.
@@ -189,6 +191,8 @@ module Liquid2
     attr_reader markup_tag_end: String
 
     attr_reader markup_tag_start: String
+
+    attr_reader universal_markup_end: bool
 
     attr_reader re_tag_name: Regexp
 
@@ -393,6 +397,8 @@ module Liquid2
 
     @whitespace_carry: String?
 
+    @output_end: Symbol
+
     # Parse Liquid template text into a syntax tree.
     # @param source [String]
     # @return [Array[Node | String]]
@@ -518,13 +524,13 @@ module Liquid2
 
       MEMBERSHIP: 6
 
-      PREFIX: 7
-
       ADD_SUB: 8
 
       MUL_DIV: 9
       
       POW: 10
+
+      PREFIX: 11
     end
 
     PRECEDENCES: Hash[Symbol, Integer]

--- a/test/test_issues.rb
+++ b/test/test_issues.rb
@@ -13,4 +13,21 @@ class TestIssues < Minitest::Test
 
     assert_equal("42 43 44 45 46", Liquid2.render(source, data))
   end
+
+  def test_issue23
+    env = Liquid2::Environment.new(
+      markup_out_start: "<%=",
+      markup_out_end: "%>",
+      markup_tag_start: "<%",
+      markup_tag_end: "%>"
+    )
+
+    source = <<~LIQUID
+      <% if true %>
+        Hello, <%= you %>!
+      <% endif %>
+    LIQUID
+
+    assert_equal("\n  Hello, World!\n\n", env.render(source, "you" => "World"))
+  end
 end


### PR DESCRIPTION
This PR fixes a bug where the parser would raise a `Liquid2::LiquidSyntaxError` if environment arguments `markup_out_end` and `markup_tag_end` where identical.

Closes #23 