### PR TITLE
Improve cycle tag implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Improved array literal syntax. Arrays with square brackets are now allowed anywhere a value (literal or variable) is expected. See [#21](https://github.com/jg-rp/ruby-liquid2/issues/21) and `docs/composite_literals.md`.
 - Added object (aka hash) literal syntax. Like arrays, object literals are allowed anywhere a value (literal or variable) is expected. See `docs/composite_literals.md`.
 - Added the spread operator `...`. Like spread syntax in JavaScript, the spread operator is used to expand array elements inside array literals and merge objects (aka hashes) in object literals. See `docs/composite_literals.md`.
+- Improved `{% cycle %}` tag implementation. We no longer evaluate all items for every call to `CycleTag#render`, just the next item in the cycle. We also cache cycle context keys if the key is known at parse time.
 
 ## [0.4.0] - 25-08-11
 

--- a/lib/liquid2/nodes/tags/cycle.rb
+++ b/lib/liquid2/nodes/tags/cycle.rb
@@ -39,19 +39,14 @@ module Liquid2
       @items = items
       @named = named
       @blank = false
+      # Generate the cycle key here once if we don't have a potentially dynamic name.
+      @key = @items.to_s unless @named
     end
 
     def render(context, buffer)
-      args = @items.map { |expr| context.evaluate(expr) }
-
-      key = if @named
-              context.evaluate(@name).to_s
-            else
-              @items.to_s
-            end
-
+      key = @key || context.evaluate(@name).to_s
       index = context.tag_namespace[:cycles][key]
-      buffer << Liquid2.to_output_s(args[index])
+      buffer << Liquid2.to_output_s(context.evaluate(@items[index]))
 
       index += 1
       index = 0 if index >= @items.length

--- a/sig/liquid2.rbs
+++ b/sig/liquid2.rbs
@@ -2185,6 +2185,8 @@ module Liquid2
 
     @blank: bool
 
+    @key: String | nil
+
     # @param parser [Parser]
     # @return [CycleTag]
     def self.parse: ([Symbol, String?, Integer] token, Parser parser) -> CycleTag


### PR DESCRIPTION
This PR simplifies and optimizes our implementation of the `{% cycle %}` tag. Closes #29 