### PR TITLE
Add contributing guide and fix `profile.rb`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to Ruby Liquid2
+
+Your contributions and questions are always welcome. Feel free to ask questions, report bugs or request features on the [issue tracker](https://github.com/jg-rp/ruby-liquid2/issues) or on [Github Discussions](https://github.com/jg-rp/ruby-liquid2/discussions). Pull requests are welcome too.
+
+## Development
+
+The [Golden Liquid Test Suite](https://github.com/jg-rp/golden-liquid) is included in this repository as a Git [submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules). Clone the Ruby Liquid2 repository and initialize the submodule with something like this:
+
+```shell
+$ git clone git@github.com:jg-rp/ruby-liquid2.git
+$ cd ruby-liquid2
+$ git submodule update --init
+```
+
+We use [Bundler](https://bundler.io/) and [Rake](https://ruby.github.io/rake/). Install development dependencies with:
+
+```
+bundle install
+```
+
+Run tests with:
+
+```
+bundle exec rake test
+```
+
+Lint with:
+
+```
+bundle exec rubocop
+```
+
+And type check with:
+
+```
+bundle exec steep
+```
+
+Run one of the benchmarks with:
+
+```
+bundle exec ruby performance/benchmark.rb
+```
+
+Don't forget to benchmark with YJIT too:
+
+```
+bundle exec ruby --yjit performance/benchmark.rb
+```
+
+## Profiling
+
+### CPU profile
+
+Dump profile data with `bundle exec ruby performance/profile.rb`, then generate an HTML flame graphs with:
+
+```
+bundle exec stackprof --d3-flamegraph .stackprof-cpu-scan.dump > flamegraph-cpu-scan.html
+bundle exec stackprof --d3-flamegraph .stackprof-cpu-parse.dump > flamegraph-cpu-parse.html
+bundle exec stackprof --d3-flamegraph .stackprof-cpu-render.dump > flamegraph-cpu-render.html
+```
+
+### Memory profile
+
+Print memory usage to the terminal.
+
+```
+bundle exec ruby performance/memory_profile.rb
+```
+
+Don't forget to inspect memory usage with YJIT enabled too.
+
+```
+bundle exec ruby --yjit performance/memory_profile.rb
+```

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Logical expressions now support negation with the `not` operator and grouping te
 
 In this example, `{% if not user %}` is equivalent to `{% unless user %}`, however, `not` can also be used after `and` and `or`, like `{% if user.active and not user.title %}`, potentially saving nested `if` and `unless` tags.
 
-```liquid2
+```liquid
 {% if not user %}
   please log in
 {% else %}
@@ -613,63 +613,9 @@ end
 puts Liquid2.render("{% if x == 'foo' %}true{% else %}false{% endif %}", "x" => MyDrop.new) # true
 ```
 
-## Development
+## Contributing
 
-The [golden liquid](https://github.com/jg-rp/golden-liquid) test suite is included in this repository as a Git [submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules). Clone this project and initialize the submodule with something like:
-
-```shell
-$ git clone git@github.com:jg-rp/ruby-liquid2.git
-$ cd ruby-liquid2
-$ git submodule update --init
-```
-
-We use [Bundler](https://bundler.io/) and [Rake](https://ruby.github.io/rake/). Install development dependencies with:
-
-```
-bundle install
-```
-
-Run tests with:
-
-```
-bundle exec rake test
-```
-
-Lint with:
-
-```
-bundle exec rubocop
-```
-
-And type check with:
-
-```
-bundle exec steep
-```
-
-Run one of the benchmarks with:
-
-```
-bundle exec ruby performance/benchmark.rb
-```
-
-### Profiling
-
-#### CPU profile
-
-Dump profile data with `bundle exec ruby performance/profile.rb`, then generate an HTML flame graph with, changing the file names appropriately:
-
-```
-bundle exec stackprof --d3-flamegraph .stackprof-cpu-parse.dump > flamegraph-cpu-parse.html
-```
-
-#### Memory profile
-
-Print memory usage to the terminal.
-
-```
-bundle exec ruby performance/memory_profile.rb
-```
+Please see [Contributing to Ruby Liquid2](https://github.com/jg-rp/ruby-liquid2/blob/main/CONTRIBUTING.md).
 
 ## License
 

--- a/performance/benchmark.rb
+++ b/performance/benchmark.rb
@@ -31,7 +31,7 @@ options = {
 
 OptionParser.new do |parser|
   parser.banner = <<~BANNER
-    Run one of the benchmarks in ./tests/cts/benchmark_fixtures.
+    Run one of the benchmarks in ./tests/golden_liquid/benchmark_fixtures.
     Example: ruby benchmark.rb -f 002
   BANNER
 

--- a/performance/memory_profile.rb
+++ b/performance/memory_profile.rb
@@ -33,7 +33,7 @@ options = {
 
 OptionParser.new do |parser|
   parser.banner = <<~BANNER
-    Run one of the benchmarks in ./tests/cts/benchmark_fixtures.
+    Run one of the benchmarks in ./tests/golden_liquid/benchmark_fixtures.
     Example: ruby benchmark.rb -f 002
   BANNER
 

--- a/performance/profile.rb
+++ b/performance/profile.rb
@@ -31,7 +31,7 @@ options = {
 
 OptionParser.new do |parser|
   parser.banner = <<~BANNER
-    Run one of the benchmarks in ./tests/cts/benchmark_fixtures.
+    Run one of the benchmarks in ./tests/golden_liquid/benchmark_fixtures.
     Example: ruby benchmark.rb -f 002
   BANNER
 
@@ -54,7 +54,7 @@ scanner = StringScanner.new("")
 
 StackProf.run(mode: :cpu, raw: true, out: ".stackprof-cpu-scan.dump") do
   n.times do
-    Liquid2::Scanner.tokenize(source, scanner)
+    Liquid2::Scanner.tokenize(env, source, scanner)
   end
 end
 

--- a/test/test_compliance.rb
+++ b/test/test_compliance.rb
@@ -3,10 +3,15 @@
 require "json"
 require "test_helper"
 
+begin
+  TEST_CASES = JSON.load_file("test/golden_liquid/golden_liquid.json")
+rescue Errno::ENOENT
+  puts "Error: uninitialized submodule. Try `git submodule update --init`"
+  exit(1)
+end
+
 class TestCompliance < Minitest::Spec
   make_my_diffs_pretty!
-
-  TEST_CASES = JSON.load_file("test/golden_liquid/golden_liquid.json")
 
   # rubocop:disable Layout/LineLength
   SKIP = Set[


### PR DESCRIPTION
This PR:

- Updates project development info and moves it to `CONTRIBUTING.md`.
- Fixes `performance/profile.rb` by passing `env` to `Liquid2::Scanner.tokenize`
- Displays a useful error message if the Git submodule has not been initialized when running `rake test`.